### PR TITLE
feat(auth): fix deep link re-launch and add waiting overlay on desktop

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,6 +17,7 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = [] }
 tauri-plugin-deep-link = "2"
 tauri-plugin-opener = "2"
+tauri-plugin-single-instance = "2"
 tauri-plugin-updater = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use tauri::{AppHandle, WebviewUrl, WebviewWindowBuilder};
+use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
 
 #[cfg(windows)]
 mod thumbar;
@@ -34,6 +34,15 @@ fn open_spotify_auth(_app: AppHandle, url: String) -> Result<(), String> {
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_updater::Builder::new().build())
+        .plugin(tauri_plugin_single_instance::init(|app, argv, _cwd| {
+            if let Some(window) = app.get_webview_window("main") {
+                let _ = window.show();
+                let _ = window.set_focus();
+            }
+            if let Some(url) = argv.iter().skip(1).find(|a| a.starts_with("beardify://")) {
+                app.emit("deep-link-urls", vec![url.clone()]).ok();
+            }
+        }))
         .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_opener::init())
         .invoke_handler(tauri::generate_handler![set_play_state, open_spotify_auth])

--- a/src/App.vue
+++ b/src/App.vue
@@ -124,6 +124,7 @@ onBeforeUnmount(() => {
 </script>
 
 <style lang="scss">
+@use "@/assets/scss/button";
 @use "@/assets/scss/colors" as colors;
 @use "@/assets/scss/font-size" as *;
 @use "@/assets/scss/responsive" as responsive;

--- a/src/assets/scss/button.scss
+++ b/src/assets/scss/button.scss
@@ -1,0 +1,48 @@
+.button {
+  align-items: center;
+  border-radius: 2rem;
+  cursor: pointer;
+  display: inline-flex;
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  gap: 0.5rem;
+  letter-spacing: 0.03em;
+  padding: 0.75rem 1.75rem;
+  text-decoration: none;
+  transition:
+    background-color 0.15s ease,
+    transform 0.1s ease;
+
+  &:active {
+    transform: scale(0.97);
+  }
+}
+
+.button-primary {
+  background-color: var(--primary-color);
+  color: #fff;
+
+  &:hover {
+    background-color: var(--primary-color-light);
+  }
+}
+
+.button-spotify {
+  background-color: #1db954;
+  color: #fff;
+
+  &:hover {
+    background-color: #1ed760;
+  }
+}
+
+.button-ghost {
+  background-color: transparent;
+  border: 1px solid rgb(255 255 255 / 20%);
+  color: var(--font-color);
+
+  &:hover {
+    background-color: rgb(255 255 255 / 8%);
+    border-color: rgb(255 255 255 / 35%);
+  }
+}

--- a/src/helpers/tauriBootstrap.ts
+++ b/src/helpers/tauriBootstrap.ts
@@ -35,11 +35,17 @@ function handleAuthUrl(url: string): void {
 
 async function setupDeepLink(): Promise<void> {
   const { getCurrent, onOpenUrl } = await import("@tauri-apps/plugin-deep-link");
+  const { listen } = await import("@tauri-apps/api/event");
 
   const [initial] = await Promise.all([
     getCurrent(),
     onOpenUrl((urls: string[]) => {
       if (urls.length > 0) handleAuthUrl(urls[0]);
+    }),
+    // deep-link plugin only fires onOpenUrl for new instances; this catches URLs forwarded
+    // by single-instance when the OS re-launches the app with a beardify:// argument
+    listen<string[]>("deep-link-urls", ({ payload }) => {
+      if (payload.length > 0) handleAuthUrl(payload[0]);
     }),
   ]);
 

--- a/src/views/LoginPage.vue
+++ b/src/views/LoginPage.vue
@@ -1,5 +1,15 @@
 <template>
   <div class="login">
+    <Transition name="fade">
+      <div v-if="waiting" class="waiting-overlay">
+        <div class="waiting-card">
+          <LoadingDots />
+          <p class="waiting-label">Waiting for Spotify authorization…</p>
+          <button class="button button-ghost" @click="cancelWaiting">Cancel</button>
+        </div>
+      </div>
+    </Transition>
+
     <div class="form">
       <img alt="" class="logo" src="/img/logo-long.svg" />
       <div class="pres">
@@ -23,16 +33,14 @@
           </li>
         </ul>
       </div>
-      <div>
-        <a
-          :href="spotifyAuthUrl"
-          class="button button-primary"
-          @click.prevent="handleLogin"
-        >
-          <i class="icon icon-spotify" />
-          Connect with Spotify (Premium)
-        </a>
-      </div>
+      <a
+        :href="spotifyAuthUrl"
+        class="button button-spotify"
+        @click.prevent="handleLogin"
+      >
+        <i class="icon icon-spotify" />
+        Connect with Spotify (Premium)
+      </a>
     </div>
   </div>
 </template>
@@ -41,49 +49,53 @@
 import { computed, ref } from "vue";
 
 import { api } from "@/api";
+import LoadingDots from "@/components/ui/LoadingDots.vue";
 import { clearAuthData } from "@/helpers/authUtils";
 import { isTauri } from "@/helpers/platform";
 import router, { RouteName } from "@/router";
 import { useAuth } from "@/views/auth/AuthStore";
 
 const authStore = useAuth();
-const challenge = ref<string | undefined>(undefined);
+const waiting = ref(false);
 
 const spotifyAuthUrl = computed(
   () =>
-    `https://accounts.spotify.com/authorize?response_type=code&client_id=${api.clientId}&redirect_uri=${api.redirectUri}&scope=${api.scopes}&code_challenge_method=S256&code_challenge=${challenge.value}`,
+    `https://accounts.spotify.com/authorize?response_type=code&client_id=${api.clientId}&redirect_uri=${api.redirectUri}&scope=${api.scopes}&code_challenge_method=S256&code_challenge=${authStore.storage?.codeChallenge}`,
 );
+
+async function refreshChallenge(): Promise<void> {
+  await authStore.generateStorage(router.currentRoute.value.query.ref?.toString());
+}
 
 async function handleLogin(): Promise<void> {
   if (isTauri()) {
     const { invoke } = await import("@tauri-apps/api/core");
     await invoke("open_spotify_auth", { url: spotifyAuthUrl.value });
+    waiting.value = true;
   } else {
     window.location.href = spotifyAuthUrl.value;
   }
 }
 
+async function cancelWaiting(): Promise<void> {
+  waiting.value = false;
+  await refreshChallenge();
+}
+
 (async () => {
-  // If user already has a valid token, redirect to home
   if (authStore.accessToken && authStore.storage?.refreshToken) {
     try {
-      // Try to refresh to check if token is still valid
       await authStore.refresh();
-      // If successful, redirect to home
       router.push(RouteName.Home);
       return;
     } catch {
-      // If refresh fails, continue with normal login flow
       clearAuthData();
     }
   }
 
-  // Only generate new storage if we don't have valid PKCE codes
-  // Don't call clearAuthData() here - it would wipe the codeVerifier needed after Spotify redirect
   if (!authStore.storage?.codeChallenge || !authStore.storage?.codeVerifier) {
-    await authStore.generateStorage(router.currentRoute.value.query.ref?.toString());
+    await refreshChallenge();
   }
-  challenge.value = authStore.storage?.codeChallenge;
 })();
 </script>
 
@@ -137,9 +149,45 @@ b {
 }
 
 .icon {
-  font-size: var(--font-size-xl);
-  margin-right: 0.3rem;
-  position: relative;
-  top: 0.2rem;
+  font-size: 1.2rem;
+}
+
+.waiting-overlay {
+  align-items: center;
+  background-color: rgb(0 0 0 / 70%);
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+  z-index: 10;
+}
+
+.waiting-card {
+  align-items: center;
+  background-color: var(--bg-color-dark);
+  border-radius: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 2.5rem 3rem;
+}
+
+.waiting-label {
+  color: var(--font-color-light);
+  font-size: var(--font-size-sm);
+  margin: 0;
+}
+
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
 }
 </style>

--- a/src/views/LoginPage.vue
+++ b/src/views/LoginPage.vue
@@ -63,8 +63,9 @@ const spotifyAuthUrl = computed(
     `https://accounts.spotify.com/authorize?response_type=code&client_id=${api.clientId}&redirect_uri=${api.redirectUri}&scope=${api.scopes}&code_challenge_method=S256&code_challenge=${authStore.storage?.codeChallenge}`,
 );
 
-async function refreshChallenge(): Promise<void> {
-  await authStore.generateStorage(router.currentRoute.value.query.ref?.toString());
+async function cancelWaiting(): Promise<void> {
+  waiting.value = false;
+  await refreshChallenge();
 }
 
 async function handleLogin(): Promise<void> {
@@ -77,9 +78,8 @@ async function handleLogin(): Promise<void> {
   }
 }
 
-async function cancelWaiting(): Promise<void> {
-  waiting.value = false;
-  await refreshChallenge();
+async function refreshChallenge(): Promise<void> {
+  await authStore.generateStorage(router.currentRoute.value.query.ref?.toString());
 }
 
 (async () => {


### PR DESCRIPTION
## Summary

- Add `tauri-plugin-single-instance` so Spotify's OAuth redirect no longer opens a second app instance; the existing window is focused and the deep link URL is forwarded via a custom `deep-link-urls` event
- Add a waiting overlay on the login page (spinner + cancel) shown after the Spotify auth tab opens, so the user knows the app is waiting for the callback
- Add global `button.scss` with `.button-primary` (app purple), `.button-spotify` (Spotify green), and `.button-ghost` variants

## Details

- `single-instance` plugin must be registered before `deep-link` so the deep-link plugin can relay URLs to the running instance
- Rust callback skips `argv[0]` (exe path) when scanning for `beardify://` URLs
- `challenge` ref removed from `LoginPage.vue` — computed reads `authStore.storage?.codeChallenge` directly
- Spinner replaced by existing `LoadingDots.vue`; duplicate `generateStorage` logic extracted to `refreshChallenge()`

