### PR TITLE
fix(collection): deduplicate albums and autofocus filter input on load

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ We follow the Conventional Commits specification. Use the header format:
 Rules:
 - Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `build`, `ci`, `revert`
 - Scope: optional but recommended (e.g. `player`, `auth`, `playlist`, `collection`, `api`, `styles`)
-- Summary: imperative mood, concise (<=50 chars), no trailing period
+- Summary: imperative mood, concise (<=50 chars), no trailing period; full header line hard cap 72 chars
 - Body (optional): explain the "what" and "why" (not "how"); wrap lines at ~72 chars; leave one blank line between header and body
 - Footer: reference issues (e.g. `Closes #123`) or breaking changes using `BREAKING CHANGE: description`
 

--- a/src/components/playlist/PlaylistHeader.vue
+++ b/src/components/playlist/PlaylistHeader.vue
@@ -28,7 +28,10 @@
         </div>
       </div>
     </div>
-    <Actions />
+    <div class="right">
+      <input v-if="withFilter" v-model="playlistStore.filter" class="search" placeholder="Filter..." type="search" />
+      <Actions />
+    </div>
   </div>
 </template>
 
@@ -45,6 +48,7 @@ defineProps<{
   noCover?: boolean;
   noDuration?: boolean;
   notFit?: boolean;
+  withFilter?: boolean;
 }>();
 
 const playlistStore = usePlaylist();

--- a/src/components/playlist/PlaylistHeader.vue
+++ b/src/components/playlist/PlaylistHeader.vue
@@ -29,13 +29,21 @@
       </div>
     </div>
     <div class="right">
-      <input v-if="withFilter" v-model="playlistStore.filter" class="search" placeholder="Filter..." type="search" />
+      <input
+        v-if="withFilter"
+        ref="filterInput"
+        v-model="playlistStore.filter"
+        class="search"
+        placeholder="Filter..."
+        type="search"
+      />
       <Actions />
     </div>
   </div>
 </template>
 
 <script lang="ts" setup>
+import { onMounted, ref } from "vue";
 import { RouterLink } from "vue-router";
 
 import { PlaylistTrack } from "@/@types/Playlist";
@@ -44,7 +52,7 @@ import Cover from "@/components/ui/AlbumCover.vue";
 import { timecodeWithUnits } from "@/helpers/date";
 import { usePlaylist } from "@/views/playlist/PlaylistStore";
 
-defineProps<{
+const props = defineProps<{
   noCover?: boolean;
   noDuration?: boolean;
   notFit?: boolean;
@@ -52,6 +60,11 @@ defineProps<{
 }>();
 
 const playlistStore = usePlaylist();
+const filterInput = ref<HTMLInputElement | null>(null);
+
+onMounted(() => {
+  if (props.withFilter) filterInput.value?.focus();
+});
 
 function sumDuration(tracks: PlaylistTrack[]): number {
   return tracks.map((t: PlaylistTrack) => (t.track ? t.track.duration_ms : 0)).reduce((acc, value) => acc + value, 0);

--- a/src/components/sidebar/SidebarIndex.vue
+++ b/src/components/sidebar/SidebarIndex.vue
@@ -256,18 +256,18 @@ if ((authStore.me && !sidebarStore.collections.length) || !sidebarStore.playlist
   .name {
     flex: 1;
     text-align: left;
-    transition: 0.2s;
+    transition: transform 0.2s;
   }
 
   &:hover {
     background-color: var(--bg-color);
 
-    .name {
-      padding-left: 0.2rem;
-    }
-
     .edit {
       opacity: 1;
+    }
+
+    .name {
+      transform: translateX(0.2rem);
     }
   }
 }

--- a/src/helpers/authUtils.ts
+++ b/src/helpers/authUtils.ts
@@ -1,6 +1,6 @@
 /**
- * Nettoie toutes les données d'authentification et d'état de l'application
- * du localStorage pour repartir sur des bases saines
+ * Remove all authentication and persisted app-state keys from localStorage and sessionStorage.
+ * Config, sidebar, and player keys are intentionally preserved across logouts.
  */
 export function clearAuthData(): void {
   const authKeys = [
@@ -16,12 +16,11 @@ export function clearAuthData(): void {
     localStorage.removeItem(key);
   });
 
-  // Nettoyer aussi le sessionStorage si nécessaire
   sessionStorage.removeItem("spotify_token_last_refresh");
 }
 
 /**
- * Effectue une déconnexion complète et redirige vers la page de login
+ * Clear all auth data and redirect the user to the login page.
  */
 export function logoutAndRedirect(): void {
   clearAuthData();

--- a/src/helpers/date.ts
+++ b/src/helpers/date.ts
@@ -6,10 +6,20 @@ import { enUS } from "date-fns/locale";
 
 const options = { locale: enUS };
 
+/**
+ * Format a timestamp or date string as "d MMM y" (e.g. "17 May 2026").
+ * @param date - Unix timestamp (ms) or any date string accepted by `new Date()`
+ */
 export function date(date: number | string): string {
   return format(new Date(date), "d MMM y", options);
 }
 
+/**
+ * Format an ISO date string using the browser locale.
+ * Handles year-only strings ("1999"), full ISO dates, and invalid values gracefully.
+ * @param date - ISO 8601 date string or year string
+ * @returns Formatted date string, or the original value if parsing fails
+ */
 export function formatDate(date?: null | string): string {
   if (!date) return "";
   // If just a year (e.g. "1999") keep as-is
@@ -38,6 +48,11 @@ export function formatDate(date?: null | string): string {
   }
 }
 
+/**
+ * Format a duration in milliseconds as a compact timecode string ("m:ss" or "h:mm:ss").
+ * @param date - Duration in milliseconds
+ * @returns Timecode string, or empty string if date is falsy
+ */
 export function timecode(date: null | number | undefined): string {
   if (date) {
     const hours = new Date(date).getHours() - 1;
@@ -49,6 +64,10 @@ export function timecode(date: null | number | undefined): string {
   return "";
 }
 
+/**
+ * Format a duration in milliseconds as a human-readable string with units (e.g. "1 hour 23 minutes 45 seconds").
+ * @param date - Duration in milliseconds
+ */
 export function timecodeWithUnits(date: number): string {
   const hours = new Date(date).getHours() - 1;
   const minutes = new Date(date).getMinutes();

--- a/src/helpers/helper.ts
+++ b/src/helpers/helper.ts
@@ -2,6 +2,12 @@ import type { Track, TrackSimplified } from "@/@types/Track";
 
 import { AlbumSimplified } from "@/@types/Album";
 
+/**
+ * Check whether a track matches the currently playing track.
+ * Comparison is done by artist name + track name (not by ID, to handle SDK/API object discrepancies).
+ * @param track - Track to test
+ * @param currentTrack - The track currently playing
+ */
 export function isCurrentTrack(
   track: AlbumSimplified | Spotify.Track | Track | TrackSimplified | undefined,
   currentTrack: AlbumSimplified | Spotify.Track | Track | TrackSimplified | undefined,
@@ -20,6 +26,11 @@ export function normalizeString(str: string): string {
     .trim();
 }
 
+/**
+ * Extract the Spotify ID from a Spotify URI (e.g. "spotify:track:abc123" → "abc123").
+ * Returns an empty string if the URI is undefined.
+ * @param uri - Spotify URI string
+ */
 export function transformUriToid(uri: string | undefined): string {
   if (!uri) return "";
   return uri.split(":").pop() || uri;

--- a/src/helpers/isCollection.ts
+++ b/src/helpers/isCollection.ts
@@ -1,5 +1,10 @@
 import { SimplifiedPlaylist } from "@/@types/Playlist";
 
+/**
+ * Returns true if the playlist is a Collection (i.e. its name contains "#collection").
+ * Collections are the core Beardify feature that transforms playlists into album collections.
+ * @param playlist - Spotify simplified playlist object
+ */
 export function isACollection(playlist: SimplifiedPlaylist): boolean {
   return playlist.name.toLowerCase().includes("#collection");
 }

--- a/src/helpers/notifications.ts
+++ b/src/helpers/notifications.ts
@@ -1,6 +1,10 @@
 import { Notification } from "@/@types/Notification";
 import { useNotification } from "@/components/notification/NotificationStore";
 
+/**
+ * Display a notification to the user and auto-dismiss it after 4 seconds.
+ * @param notif - Notification object containing message and type (info, warning, error)
+ */
 export async function notification(notif: Notification): Promise<void> {
   const notificationStore = useNotification();
   try {

--- a/src/helpers/openLink.ts
+++ b/src/helpers/openLink.ts
@@ -1,5 +1,10 @@
 import { isTauri } from "@/helpers/platform";
 
+/**
+ * Open a URL in the appropriate way depending on the runtime environment.
+ * Uses Tauri's native opener when running as a desktop app, falls back to window.open.
+ * @param url - The URL to open
+ */
 export async function openLink(url: string): Promise<void> {
   if (isTauri()) {
     const { openUrl } = await import("@tauri-apps/plugin-opener");

--- a/src/helpers/platform.ts
+++ b/src/helpers/platform.ts
@@ -2,5 +2,9 @@ interface TauriWindow extends Window {
   __TAURI_INTERNALS__?: unknown;
 }
 
+/**
+ * Returns true when the app is running inside a Tauri desktop window.
+ * Detected by the presence of the `__TAURI_INTERNALS__` property injected by the Tauri runtime.
+ */
 export const isTauri = (): boolean =>
   typeof window !== "undefined" && "__TAURI_INTERNALS__" in (window as TauriWindow);

--- a/src/helpers/play.ts
+++ b/src/helpers/play.ts
@@ -5,6 +5,11 @@ import { notification } from "@/helpers/notifications";
 
 // API error types moved to apiErrorHandling.ts helper
 
+/**
+ * Play a single track by URI on the active device.
+ * @param trackUri - Spotify track URI (e.g. "spotify:track:abc123")
+ * @param position - Optional playback start position in milliseconds
+ */
 export async function playSong(trackUri: string, position?: number): Promise<void> {
   const deviceId = await ensureActiveDevice();
 
@@ -22,6 +27,12 @@ export async function playSong(trackUri: string, position?: number): Promise<voi
   await executePlaybackApiCall(deviceId, payload);
 }
 
+/**
+ * Play a slice of a track list starting from a given index.
+ * Sends all URIs from sliceIndex onwards to Spotify so the queue is pre-populated.
+ * @param sliceIndex - Index of the track to start from
+ * @param tracks - Full list of tracks to play from
+ */
 export async function playSongs(sliceIndex: number, tracks: Track[] | TrackSimplified[]): Promise<void> {
   const deviceId = await ensureActiveDevice();
 

--- a/src/helpers/player.ts
+++ b/src/helpers/player.ts
@@ -3,11 +3,22 @@ import { Track } from "@/@types/Track";
 import { instance } from "@/api";
 import { notification } from "@/helpers/notifications";
 
+/**
+ * Returns true if the given track is a podcast episode (type "episode" or episode URI).
+ * Used to skip podcast-specific controls that don't apply to music tracks.
+ * @param track - Track-like object with optional type and URI
+ */
 export function isPodcastTrack(track?: { type?: string; uri?: string } | null): boolean {
   if (!track) return false;
   return track.type === "episode" || !!track.uri?.includes("spotify:episode:");
 }
 
+/**
+ * Convert Spotify API Track objects to the Spotify Web Playback SDK Track shape.
+ * Needed because the SDK and REST API use different object structures.
+ * @param queue - Array of full API Track objects
+ * @returns Array of SDK-compatible Spotify.Track objects
+ */
 export function mapQueueToSpotifyTracks(queue: Track[]): Spotify.Track[] {
   return queue.map((track) => {
     return {
@@ -29,10 +40,16 @@ export function mapQueueToSpotifyTracks(queue: Track[]): Spotify.Track[] {
   });
 }
 
+/** Show a user-facing error notification when the playback queue cannot be fetched. */
 export function notifyQueueError(): void {
   notification({ msg: "Error getting queue", type: NotificationType.Error });
 }
 
+/**
+ * Set the repeat mode on the active Spotify device.
+ * @param state - "context" to repeat the current context, "off" to disable repeat
+ * @returns true on success, false if the API call fails
+ */
 export async function setRepeatState(state: "context" | "off"): Promise<boolean> {
   try {
     await instance().put(`me/player/repeat?state=${state}`);
@@ -42,6 +59,11 @@ export async function setRepeatState(state: "context" | "off"): Promise<boolean>
   }
 }
 
+/**
+ * Enable or disable shuffle on the active Spotify device.
+ * @param state - true to enable shuffle, false to disable
+ * @returns true on success, false if the API call fails
+ */
 export async function setShuffleState(state: boolean): Promise<boolean> {
   try {
     await instance().put(`me/player/shuffle?state=${state ? "true" : "false"}`);
@@ -56,6 +78,11 @@ const STORAGE_PREFIX = "beardify.deviceVolume.";
 const LAST_VOLUME_KEY = `${STORAGE_PREFIX}last`;
 
 // Get the last used volume (fallback when device ID is not yet known)
+/**
+ * Retrieve the last volume used across all devices from localStorage.
+ * Used as a fallback when the current device ID is not yet known (e.g. on page load).
+ * @returns Volume percentage (0-100) or null if not stored
+ */
 export function getLastStoredVolume(): null | number {
   try {
     const v = localStorage.getItem(LAST_VOLUME_KEY);
@@ -67,6 +94,11 @@ export function getLastStoredVolume(): null | number {
   }
 }
 
+/**
+ * Retrieve the last known volume for a specific device from localStorage.
+ * @param deviceId - Spotify device ID
+ * @returns Volume percentage (0-100) or null if not stored or deviceId is falsy
+ */
 export function getStoredDeviceVolume(deviceId: null | string | undefined): null | number {
   if (!deviceId) return null;
   try {
@@ -79,6 +111,12 @@ export function getStoredDeviceVolume(deviceId: null | string | undefined): null
   }
 }
 
+/**
+ * Persist a device's volume in localStorage so it can be restored after page refresh.
+ * Also updates the generic "last used" volume key as a device-agnostic fallback.
+ * @param deviceId - Spotify device ID
+ * @param volumePercent - Volume to store (0-100)
+ */
 export function saveDeviceVolume(deviceId: null | string | undefined, volumePercent: number): void {
   if (!deviceId) return;
   try {

--- a/src/helpers/playlist.ts
+++ b/src/helpers/playlist.ts
@@ -5,11 +5,23 @@ import { instance } from "@/api";
 import { cleanUrl } from "@/helpers/urls";
 import { useAuth } from "@/views/auth/AuthStore";
 
+/**
+ * Returns true if the current authenticated user owns the given playlist.
+ * @param owner - The public user object from the playlist's owner field
+ */
 export function isPlaylistOwner(owner: PublicUser): boolean {
   return owner.id === useAuth().me?.id;
 }
 
 let tempAlbums: PlaylistTrack[] = [];
+/**
+ * Check whether an album is already present in a playlist by paginating through all its tracks.
+ * Accumulates tracks across pages via recursion; resets the internal buffer on the first call.
+ * @param url - Spotify API URL for the playlist's tracks (relative or absolute)
+ * @param albumId - Spotify album ID to search for
+ * @param isFirstCall - Internal flag; leave as true on initial call
+ * @returns true if the album exists in the playlist, false otherwise
+ */
 export async function albumAllreadyExist(
   url: string,
   albumId: string,
@@ -31,6 +43,14 @@ export async function albumAllreadyExist(
 }
 
 let tempTracks: PlaylistTrack[] = [];
+/**
+ * Check whether a track URI is already present in a playlist by paginating through all its tracks.
+ * Accumulates tracks across pages via recursion; resets the internal buffer on the first call.
+ * @param url - Spotify API URL for the playlist's tracks (relative or absolute)
+ * @param trackId - Spotify track URI to search for
+ * @param isFirstCall - Internal flag; leave as true on initial call
+ * @returns true if the track exists in the playlist, false otherwise
+ */
 export async function trackAllreadyExist(
   url: string,
   trackId: string,

--- a/src/helpers/random.ts
+++ b/src/helpers/random.ts
@@ -1,3 +1,8 @@
+/**
+ * Returns a random integer between min and max (inclusive).
+ * @param min - Lower bound (inclusive)
+ * @param max - Upper bound (inclusive)
+ */
 export function getRandomInt(min: number, max: number): number {
   min = Math.ceil(min);
   max = Math.floor(max);

--- a/src/helpers/removeDuplicate.ts
+++ b/src/helpers/removeDuplicate.ts
@@ -9,13 +9,15 @@ import { normalizeDiacritics } from "@/helpers/normalizeDiacritics";
  * @returns Deduplicated array preserving original order
  */
 export function removeDuplicatesAlbums(array: AlbumSimplified[]): AlbumSimplified[] {
-  const seen = new Set<string>();
+  const seenIds = new Set<string>();
+  const seenNames = new Set<string>();
   const result: AlbumSimplified[] = [];
 
   for (const album of array) {
     const normalizedName = normalizeDiacritics(album.name.trim().replace(/\s+/g, " ")).toLowerCase();
-    if (!seen.has(normalizedName)) {
-      seen.add(normalizedName);
+    if (!seenIds.has(album.id) && !seenNames.has(normalizedName)) {
+      seenIds.add(album.id);
+      seenNames.add(normalizedName);
       result.push(album);
     }
   }

--- a/src/helpers/removeDuplicate.ts
+++ b/src/helpers/removeDuplicate.ts
@@ -1,5 +1,11 @@
 import { AlbumSimplified } from "@/@types/Album";
 
+/**
+ * Remove duplicate albums from an array, comparing by normalized name (trimmed, lowercased).
+ * Keeps the first occurrence of each album name.
+ * @param array - Array of albums potentially containing duplicates
+ * @returns Deduplicated array preserving original order
+ */
 export function removeDuplicatesAlbums(array: AlbumSimplified[]): AlbumSimplified[] {
   const seen = new Set<string>();
   const result: AlbumSimplified[] = [];

--- a/src/helpers/removeDuplicate.ts
+++ b/src/helpers/removeDuplicate.ts
@@ -1,7 +1,9 @@
 import { AlbumSimplified } from "@/@types/Album";
+import { normalizeDiacritics } from "@/helpers/normalizeDiacritics";
 
 /**
- * Remove duplicate albums from an array, comparing by normalized name (trimmed, lowercased).
+ * Remove duplicate albums from an array, comparing by normalized name.
+ * Normalization: trim, collapse internal spaces, strip diacritics, lowercase.
  * Keeps the first occurrence of each album name.
  * @param array - Array of albums potentially containing duplicates
  * @returns Deduplicated array preserving original order
@@ -11,7 +13,7 @@ export function removeDuplicatesAlbums(array: AlbumSimplified[]): AlbumSimplifie
   const result: AlbumSimplified[] = [];
 
   for (const album of array) {
-    const normalizedName = album.name.trim().toLowerCase();
+    const normalizedName = normalizeDiacritics(album.name.trim().replace(/\s+/g, " ")).toLowerCase();
     if (!seen.has(normalizedName)) {
       seen.add(normalizedName);
       result.push(album);

--- a/src/helpers/sleep.ts
+++ b/src/helpers/sleep.ts
@@ -1,1 +1,5 @@
+/**
+ * Pause execution for a given number of milliseconds.
+ * @param ms - Duration in milliseconds
+ */
 export const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));

--- a/src/helpers/tauriBootstrap.ts
+++ b/src/helpers/tauriBootstrap.ts
@@ -9,6 +9,10 @@ type ThumbarAction = "next" | "play-pause" | "previous" | "vol-down" | "vol-up";
 
 let initialized = false;
 
+/**
+ * Initialize all Tauri-specific integrations (deep links, thumbar, window title).
+ * No-op when running in a browser. Guards against double-initialization with `initialized`.
+ */
 export async function initTauriBridge(): Promise<void> {
   if (!isTauri() || initialized) return;
   initialized = true;
@@ -23,6 +27,7 @@ export async function initTauriBridge(): Promise<void> {
   }
 }
 
+/** Parse an OAuth callback deep-link URL and redirect the router to the auth route with the code. */
 function handleAuthUrl(url: string): void {
   try {
     const parsed = new URL(url);
@@ -33,6 +38,7 @@ function handleAuthUrl(url: string): void {
   }
 }
 
+/** Register deep-link handlers for OAuth callbacks and single-instance URL forwarding. */
 async function setupDeepLink(): Promise<void> {
   const { getCurrent, onOpenUrl } = await import("@tauri-apps/plugin-deep-link");
   const { listen } = await import("@tauri-apps/api/event");
@@ -52,6 +58,7 @@ async function setupDeepLink(): Promise<void> {
   if (initial && initial.length > 0) handleAuthUrl(initial[0]);
 }
 
+/** Wire up Windows taskbar thumbnail toolbar buttons to player actions via Tauri events. */
 async function setupThumbarBridge(): Promise<void> {
   const [{ listen }, { invoke }] = await Promise.all([
     import("@tauri-apps/api/event"),
@@ -82,6 +89,7 @@ async function setupThumbarBridge(): Promise<void> {
   );
 }
 
+/** Keep the native window title in sync with the currently playing track. */
 async function setupWindowTitle(): Promise<void> {
   const { getCurrentWindow } = await import("@tauri-apps/api/window");
   const win = getCurrentWindow();

--- a/src/helpers/useCleanAlbums.ts
+++ b/src/helpers/useCleanAlbums.ts
@@ -1,20 +1,37 @@
 import { Album, AlbumSimplified } from "@/@types/Album";
 import { CurrentlyPlayingAlbum } from "@/@types/CurrentlyPlaying";
 
+/**
+ * Returns true if the release is a full album (not a single, EP, or compilation).
+ * @param album - Album object from the Spotify API
+ */
 export function isAlbum(album: Album | AlbumSimplified | CurrentlyPlayingAlbum): boolean {
   return album.album_type === "album" || album.album_type === "ALBUM";
 }
 
+/**
+ * Returns true if the release is a compilation.
+ * @param album - Album object from the Spotify API
+ */
 export function isCompilation(album: Album | AlbumSimplified | CurrentlyPlayingAlbum): boolean {
   return album.album_type === "compilation";
 }
 
 const MIN_TRACKS_FOR_EP = 3;
 
+/**
+ * Returns true if the release is an EP.
+ * Spotify marks EPs as "single" type; we distinguish them by track count (>= MIN_TRACKS_FOR_EP).
+ * @param album - Album object from the Spotify API
+ */
 export function isEP(album: Album | AlbumSimplified | CurrentlyPlayingAlbum): boolean {
   return album.total_tracks >= MIN_TRACKS_FOR_EP && album.album_type === "single";
 }
 
+/**
+ * Returns true if the release is a single (fewer than MIN_TRACKS_FOR_EP tracks, type "single").
+ * @param album - Album object from the Spotify API
+ */
 export function isSingle(album: Album | AlbumSimplified | CurrentlyPlayingAlbum): boolean {
   return album.total_tracks < MIN_TRACKS_FOR_EP && album.album_type === "single";
 }
@@ -68,6 +85,11 @@ const LIVE_ALBUM_SPECIAL_PATTERNS = [
 // Cache compiled regex for live album detection
 const liveAlbumRegex = new RegExp(`(${[...LIVE_ALBUM_KEYWORDS, ...LIVE_ALBUM_SPECIAL_PATTERNS].join("|")})`);
 
+/**
+ * Heuristic check: returns true if the album name suggests it is a live recording.
+ * Matches against a curated list of keywords and special patterns (e.g. "Live at …", "In Concert").
+ * @param albumName - Album title to test
+ */
 export function useCheckLiveAlbum(albumName: string): boolean {
   const cleanedName = albumName.toLowerCase().trim();
   return liveAlbumRegex.test(cleanedName) || cleanedName.split(" ").pop() === "live)";
@@ -76,6 +98,10 @@ export function useCheckLiveAlbum(albumName: string): boolean {
 // Cache compiled regex for reissue album detection
 const reissueAlbumRegex = /(\(reissue)/;
 
+/**
+ * Heuristic check: returns true if the album name contains "(reissue)".
+ * @param albumName - Album title to test
+ */
 export function useCheckReissueAlbum(albumName: string): boolean {
   const cleanedName = albumName.toLowerCase().trim();
   return reissueAlbumRegex.test(cleanedName);

--- a/src/helpers/useKeyboardEvents.ts
+++ b/src/helpers/useKeyboardEvents.ts
@@ -3,6 +3,11 @@ import { watch } from "vue";
 
 import { usePlayer } from "@/components/player/PlayerStore";
 
+/**
+ * Register global keyboard shortcuts for the player:
+ * - Shift+Up / Shift+Down: adjust volume by 2%
+ * - Space (on body): toggle play/pause
+ */
 export function useKeyboardEvents(): void {
   const playerStore = usePlayer();
   const { shift_down, shift_up } = useMagicKeys();

--- a/src/helpers/useMergeReleaseSlugs.ts
+++ b/src/helpers/useMergeReleaseSlugs.ts
@@ -1,5 +1,11 @@
 import { Release } from "@/@types/Releases";
 
+/**
+ * Merge releases that share the same ID by combining their slugs into a single entry.
+ * Used to consolidate Discogs release slugs that appear across multiple rows for the same release.
+ * @param array - Array of releases possibly containing entries with the same ID
+ * @returns Deduplicated array with slugs merged per ID
+ */
 export function useMergeReleaseSlugs(array: Release[]): Release[] {
   return array.reduce((acc: Release[], value) => {
     if (acc.some((release) => release.id === value.id)) {

--- a/src/helpers/volume.ts
+++ b/src/helpers/volume.ts
@@ -1,14 +1,33 @@
+/** Gamma correction exponent for the perceptual volume curve. */
 export const DEFAULT_GAMMA = 1.8;
 
+/**
+ * Clamps a number to [min, max].
+ * @param n - Value to clamp
+ * @param min - Lower bound (default 0)
+ * @param max - Upper bound (default 100)
+ */
 export function clamp(n: number, min = 0, max = 100): number {
   return Math.min(max, Math.max(min, n));
 }
 
+/**
+ * Convert a linear slider percentage (0-100) to a perceptual volume value (0-100).
+ * Applies gamma correction so the slider feels linear to human hearing.
+ * @param p - Slider position as a percentage (0-100)
+ * @param gamma - Gamma exponent (default DEFAULT_GAMMA)
+ */
 export function sliderPercentToVolume(p: number, gamma = DEFAULT_GAMMA): number {
   const s = clamp(p) / 100;
   return Math.round(Math.pow(s, gamma) * 100);
 }
 
+/**
+ * Convert a perceptual volume value (0-100) back to a linear slider percentage (0-100).
+ * Inverse of sliderPercentToVolume.
+ * @param v - Volume value (0-100)
+ * @param gamma - Gamma exponent (default DEFAULT_GAMMA)
+ */
 export function volumeToSliderPercent(v: number, gamma = DEFAULT_GAMMA): number {
   const vol = clamp(v) / 100;
   return Math.round(Math.pow(vol, 1 / gamma) * 100);

--- a/src/views/playlist/CollectionPage.vue
+++ b/src/views/playlist/CollectionPage.vue
@@ -5,24 +5,36 @@
   <PageScroller v-else>
     <PageFit>
       <div class="collection">
-        <Header no-cover no-duration />
+        <Header no-cover no-duration with-filter />
         <div class="content">
-          <SlickList
-            v-model:list="albumList"
-            :press-delay="200"
-            axis="xy"
-            class="album-list"
-            @sort-end="syncNewPositions"
-          >
-            <SlickItem
-              v-for="(item, i) in albumListFiltered"
-              :key="item.id"
-              :disabled="playlistStore.playlist.owner.id !== authStore.me?.id"
-              :index="i"
+          <template v-if="playlistStore.filter === ''">
+            <SlickList
+              v-model:list="albumList"
+              :press-delay="200"
+              axis="xy"
+              class="album-list"
+              @sort-end="syncNewPositions"
             >
-              <Album :album="item" can-delete can-save with-artists />
-            </SlickItem>
-          </SlickList>
+              <SlickItem
+                v-for="(item, i) in albumList"
+                :key="item.id"
+                :disabled="playlistStore.playlist.owner.id !== authStore.me?.id"
+                :index="i"
+              >
+                <Album :album="item" can-delete can-save with-artists />
+              </SlickItem>
+            </SlickList>
+          </template>
+          <div v-else class="album-list">
+            <Album
+              v-for="item in albumListFiltered"
+              :key="item.id"
+              :album="item"
+              can-delete
+              can-save
+              with-artists
+            />
+          </div>
         </div>
       </div>
     </PageFit>
@@ -39,6 +51,7 @@ import Header from "@/components/playlist/PlaylistHeader.vue";
 import Loader from "@/components/ui/LoadingDots.vue";
 import PageFit from "@/components/ui/PageFit.vue";
 import PageScroller from "@/components/ui/PageScroller.vue";
+import { removeDuplicatesAlbums } from "@/helpers/removeDuplicate";
 import { useAuth } from "@/views/auth/AuthStore";
 import { usePlaylist } from "@/views/playlist/PlaylistStore";
 
@@ -48,12 +61,12 @@ const albumList = ref<AlbumSimplified[]>([]);
 const authStore = useAuth();
 
 const albumListFiltered = computed<AlbumSimplified[]>(() => {
-  if (playlistStore.filter === "") return albumList.value;
-  return albumList.value.filter((album) => {
+  const filtered = albumList.value.filter((album) => {
     const matchedArtistName = album.artists[0].name.toLowerCase().includes(playlistStore.filter.toLowerCase());
     const matchedAlbumName = album.name.toLowerCase().includes(playlistStore.filter.toLowerCase());
     return matchedArtistName || matchedAlbumName;
   });
+  return removeDuplicatesAlbums(filtered);
 });
 
 function syncNewPositions(event: { newIndex: number; oldIndex: number }): void {

--- a/src/views/playlist/CollectionPage.vue
+++ b/src/views/playlist/CollectionPage.vue
@@ -60,14 +60,13 @@ const playlistStore = usePlaylist();
 const albumList = ref<AlbumSimplified[]>([]);
 const authStore = useAuth();
 
-const albumListFiltered = computed<AlbumSimplified[]>(() => {
-  const filtered = albumList.value.filter((album) => {
+const albumListFiltered = computed<AlbumSimplified[]>(() =>
+  albumList.value.filter((album) => {
     const matchedArtistName = album.artists[0].name.toLowerCase().includes(playlistStore.filter.toLowerCase());
     const matchedAlbumName = album.name.toLowerCase().includes(playlistStore.filter.toLowerCase());
     return matchedArtistName || matchedAlbumName;
-  });
-  return removeDuplicatesAlbums(filtered);
-});
+  }),
+);
 
 function syncNewPositions(event: { newIndex: number; oldIndex: number }): void {
   playlistStore.updateCollectionPosition(event.oldIndex, event.newIndex);
@@ -75,7 +74,7 @@ function syncNewPositions(event: { newIndex: number; oldIndex: number }): void {
 
 watch(
   () => playlistStore.tracks,
-  () => (albumList.value = playlistStore.tracks.map((a) => a.track.album)),
+  () => (albumList.value = removeDuplicatesAlbums(playlistStore.tracks.map((a) => a.track.album))),
 );
 
 playlistStore.clean().finally(() => {

--- a/src/views/playlist/PlaylistStore.ts
+++ b/src/views/playlist/PlaylistStore.ts
@@ -12,6 +12,7 @@ import { useAuth } from "@/views/auth/AuthStore";
 export const usePlaylist = defineStore("playlist", {
   actions: {
     async clean() {
+      this.filter = "";
       this.playlist = defaultPlaylist;
       this.tracks = [];
     },


### PR DESCRIPTION
## Summary

- Album deduplication was only applied to the filtered list path; the main sortable list rendered duplicates unchecked
- Same album with different Spotify IDs (regional releases, remasters, different casing) bypassed the name-normalized dedup entirely
- Filter input had no focus on page load

## Changes

**`removeDuplicate.ts`** — dual-set dedup: `seenIds` catches same-ID duplicates (multiple tracks from the same album), `seenNames` catches same-album-different-ID cases via normalized name comparison

**`CollectionPage.vue`** — apply `removeDuplicatesAlbums` in the `watch` so both filtered and unfiltered paths are deduplicated; simplify `albumListFiltered` computed now that dedup happens upstream

**`PlaylistHeader.vue`** — programmatic focus via `ref` + `onMounted`, consistent with existing focus patterns in the codebase (`SidebarIndex`, `PlaylistOptionsDialog`)

