### PR TITLE
feat(artist): add member timelines from Wikipedia

### DIFF
--- a/src/@types/Artist.ts
+++ b/src/@types/Artist.ts
@@ -1,4 +1,5 @@
 import type { MusicBrainzArtist } from "@/helpers/musicbrainz";
+import type { WikiTimeline } from "@/helpers/wikipediaTimeline";
 
 import { AlbumSimplified } from "./Album";
 import { Image } from "./Image";
@@ -28,6 +29,7 @@ export interface ArtistPage {
   albums: AlbumSimplified[];
   albumsLive: AlbumSimplified[];
   artist: Artist;
+  bandMembers: BandMember[];
   discogsArtist: DiscogsArtist | null;
   discogsId: null | string;
   discogsReleases: Map<string, string>;
@@ -42,6 +44,7 @@ export interface ArtistPage {
   wikidataId: null | string;
   wikipediaExtract: null | string;
   wikipediaLanguage: string;
+  wikiTimeline: null | WikiTimeline;
 }
 
 export interface ArtistSimplified {
@@ -55,6 +58,19 @@ export interface ArtistSimplified {
 
 export interface ArtistTopTracks {
   tracks: Track[];
+}
+
+/**
+ * A band member with active period and instruments, sourced from
+ * Wikidata (primary) or MusicBrainz (fallback).
+ */
+export interface BandMember {
+  begin: null | string;
+  end: null | string;
+  ended: boolean;
+  id: string;
+  instruments: string[];
+  name: string;
 }
 export interface DiscogsArtist {
   data_quality: string;

--- a/src/@types/Artist.ts
+++ b/src/@types/Artist.ts
@@ -74,11 +74,13 @@ export interface BandMember {
 }
 export interface DiscogsArtist {
   data_quality: string;
+  groups?: DiscogsGroup[];
   id: number;
   images: DiscogsImage[];
   members: DiscogsMember[];
   name: string;
   profile: string;
+  realname?: string;
   releases_url: string;
   resource_url: string;
   uri: string;
@@ -98,6 +100,14 @@ export interface DiscogsArtistReleasesResponse {
     };
   };
   releases: DiscogsRelease[];
+}
+
+export interface DiscogsGroup {
+  active: boolean;
+  id: number;
+  name: string;
+  resource_url: string;
+  thumbnail_url?: string;
 }
 
 export interface DiscogsImage {
@@ -129,6 +139,17 @@ export interface DiscogsRelease {
   title: string;
   type: "master" | "release";
   year: number;
+}
+
+/**
+ * Condensed member info shown in the reusable member popover.
+ */
+export interface MemberInfo {
+  discogsId: null | number;
+  groups: { active: boolean; name: string }[];
+  image: null | string;
+  profileUrl: null | string;
+  realName: null | string;
 }
 
 export interface RelatedArtists {

--- a/src/components/artist/ArtistInfo.vue
+++ b/src/components/artist/ArtistInfo.vue
@@ -2,7 +2,7 @@
   <div class="artist-info">
     <div class="main-content">
       <WikipediaTimeline v-if="artistStore.wikiTimeline" />
-      <MemberTimeline v-else />
+      <MemberTimeline v-else-if="artistStore.bandMembers.length > 0" />
 
       <div v-if="hasBiography" class="info-section">
         <ArtistNavigation

--- a/src/components/artist/ArtistInfo.vue
+++ b/src/components/artist/ArtistInfo.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="artist-info">
     <div class="main-content">
+      <WikipediaTimeline v-if="artistStore.wikiTimeline" />
+      <MemberTimeline v-else />
+
       <div v-if="hasBiography" class="info-section">
         <ArtistNavigation
           :sections="wikipediaSections"
@@ -41,6 +44,8 @@ import { computed, nextTick, onMounted, ref, watch } from "vue";
 
 import ArtistNavigation from "@/components/artist/ArtistNavigation.vue";
 import ArtistSidebar from "@/components/artist/ArtistSidebar.vue";
+import MemberTimeline from "@/components/artist/MemberTimeline.vue";
+import WikipediaTimeline from "@/components/artist/WikipediaTimeline.vue";
 import { type LanguageOption } from "@/components/ui/LanguageSelect.vue";
 import { parseDiscogsMarkup } from "@/helpers/discogs";
 import { useArtist } from "@/views/artist/ArtistStore";

--- a/src/components/artist/ArtistSidebar.vue
+++ b/src/components/artist/ArtistSidebar.vue
@@ -13,45 +13,43 @@
     <div v-if="activeMembers.length || formerMembers.length" class="sidebar-section">
       <h3 class="sidebar-title">Members</h3>
       <div v-if="activeMembers.length" class="sidebar-members">
-        <a
+        <MemberPopover
           v-for="member in activeMembers"
           :key="member.id"
-          :href="member.url"
-          class="sidebar-member"
-          target="_blank"
-          rel="noopener noreferrer"
+          class="sidebar-member-pop"
+          :discogs-id="member.id"
+          :name="member.name"
+          :thumbnail="member.thumbnail"
         >
-          <img v-if="member.thumbnail" :src="member.thumbnail" :alt="member.name" class="member-thumbnail" />
-          <div v-else class="member-placeholder">
-            <i class="icon-user" />
-          </div>
-          <span class="member-name">{{ member.name }}</span>
-          <div v-if="member.thumbnail" class="member-popup">
-            <img :src="member.thumbnail" :alt="member.name" />
-          </div>
-        </a>
-      </div>
-
-      <template v-if="formerMembers.length">
-        <h4 class="sidebar-subtitle">Former</h4>
-        <div class="sidebar-members">
-          <a
-            v-for="member in formerMembers"
-            :key="member.id"
-            :href="member.url"
-            class="sidebar-member inactive"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+          <a :href="member.url" class="sidebar-member" target="_blank" rel="noopener noreferrer">
             <img v-if="member.thumbnail" :src="member.thumbnail" :alt="member.name" class="member-thumbnail" />
             <div v-else class="member-placeholder">
               <i class="icon-user" />
             </div>
             <span class="member-name">{{ member.name }}</span>
-            <div v-if="member.thumbnail" class="member-popup">
-              <img :src="member.thumbnail" :alt="member.name" />
-            </div>
           </a>
+        </MemberPopover>
+      </div>
+
+      <template v-if="formerMembers.length">
+        <h4 class="sidebar-subtitle">Former</h4>
+        <div class="sidebar-members">
+          <MemberPopover
+            v-for="member in formerMembers"
+            :key="member.id"
+            class="sidebar-member-pop"
+            :discogs-id="member.id"
+            :name="member.name"
+            :thumbnail="member.thumbnail"
+          >
+            <a :href="member.url" class="sidebar-member inactive" target="_blank" rel="noopener noreferrer">
+              <img v-if="member.thumbnail" :src="member.thumbnail" :alt="member.name" class="member-thumbnail" />
+              <div v-else class="member-placeholder">
+                <i class="icon-user" />
+              </div>
+              <span class="member-name">{{ member.name }}</span>
+            </a>
+          </MemberPopover>
         </div>
       </template>
     </div>
@@ -78,6 +76,7 @@
 <script lang="ts" setup>
 import { computed } from "vue";
 
+import MemberPopover from "@/components/artist/MemberPopover.vue";
 import { useArtist } from "@/views/artist/ArtistStore";
 
 interface DetailItem {
@@ -290,29 +289,8 @@ $margin: 0.2rem;
   padding: 1rem;
 }
 
-.member-popup {
-  $size: 200px;
-
-  background-color: var(--bg-color-dark);
-  border-radius: 0.5rem;
-  box-shadow: 0 4px 20px rgb(0 0 0 / 40%);
-  opacity: 0;
-  overflow: hidden;
-  pointer-events: none;
-  position: absolute;
-  right: calc(100% + 0.75rem);
-  top: 50%;
-  transform: translateX(10px) translateY(-50%);
-  transition:
-    opacity 0.2s ease,
-    transform 0.2s ease;
-  z-index: 100;
-
-  img {
-    display: block;
-    object-fit: cover;
-    width: $size;
-  }
+.sidebar-member-pop {
+  display: block;
 }
 
 .sidebar-member {
@@ -336,12 +314,6 @@ $margin: 0.2rem;
     background-color: var(--bg-color-light);
     color: var(--font-color-default);
     z-index: 10;
-
-    .member-popup {
-      opacity: 1;
-      pointer-events: auto;
-      transform: translateX(0) translateY(-50%);
-    }
   }
 
   &.inactive {

--- a/src/components/artist/MemberPopover.vue
+++ b/src/components/artist/MemberPopover.vue
@@ -44,7 +44,9 @@
                   <span class="mp-section-title">Member of</span>
                   <ul class="mp-groups">
                     <li v-for="group in displayedGroups" :key="group.name" :class="{ former: !group.active }">
-                      <span class="mp-group-name">{{ group.name }}</span>
+                      <button class="mp-group-name" type="button" @click="searchGroup(group.name)">
+                        {{ group.name }}
+                      </button>
                       <span v-if="!group.active" class="mp-former">former</span>
                     </li>
                   </ul>
@@ -74,6 +76,8 @@ import { computed, nextTick, ref } from "vue";
 
 import type { MemberInfo } from "@/@types/Artist";
 
+import { useDialog } from "@/components/dialog/DialogStore";
+import { useSearch } from "@/components/search/SearchStore";
 import { getDiscogsMemberInfo } from "@/helpers/discogs";
 
 const props = defineProps<{
@@ -166,6 +170,14 @@ function scheduleClose(): void {
   closeTimer = setTimeout(() => {
     visible.value = false;
   }, CLOSE_DELAY);
+}
+
+function searchGroup(name: string): void {
+  visible.value = false;
+  const dialog = useDialog();
+  const search = useSearch();
+  search.updateQuery(name);
+  dialog.open({ type: "search" });
 }
 
 function updatePosition(): void {
@@ -291,7 +303,24 @@ useEventListener(window, "resize", () => visible.value && updatePosition());
 }
 
 .member-popover .mp-group-name {
+  appearance: none;
+  background: none;
+  border: none;
   color: var(--font-color-default);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+  overflow: hidden;
+  padding: 0;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  &:hover {
+    color: var(--primary-color-light);
+    text-decoration: underline;
+  }
 }
 
 .member-popover .mp-former {

--- a/src/components/artist/MemberPopover.vue
+++ b/src/components/artist/MemberPopover.vue
@@ -1,0 +1,335 @@
+<template>
+  <span
+    ref="wrapperRef"
+    class="member-popover-wrapper"
+    @focusin="open"
+    @focusout="scheduleClose"
+    @mouseenter="open"
+    @mouseleave="scheduleClose"
+  >
+    <slot />
+
+    <Teleport to="body">
+      <transition name="member-popover">
+        <div
+          v-if="visible"
+          ref="panelRef"
+          class="member-popover"
+          :style="panelStyle"
+          role="tooltip"
+          @mouseenter="cancelClose"
+          @mouseleave="scheduleClose"
+        >
+          <div class="mp-layout">
+            <div class="mp-photo-col">
+              <img v-if="image" :src="image" :alt="name" class="mp-photo" />
+              <div
+                v-else
+                class="mp-photo mp-photo-placeholder"
+                :style="{ background: `hsl(${avatarHue}, 35%, 28%)` }"
+              >
+                <span class="mp-initials">{{ initials }}</span>
+              </div>
+            </div>
+
+            <div class="mp-info-col">
+              <strong class="mp-name">{{ name }}</strong>
+              <span v-if="info?.realName && info.realName !== name" class="mp-realname">
+                {{ info.realName }}
+              </span>
+
+              <div v-if="loading" class="mp-state">Loading…</div>
+              <template v-else-if="info">
+                <div v-if="displayedGroups.length" class="mp-section">
+                  <span class="mp-section-title">Member of</span>
+                  <ul class="mp-groups">
+                    <li v-for="group in displayedGroups" :key="group.name" :class="{ former: !group.active }">
+                      <span class="mp-group-name">{{ group.name }}</span>
+                      <span v-if="!group.active" class="mp-former">former</span>
+                    </li>
+                  </ul>
+                </div>
+                <a
+                  v-if="info.profileUrl"
+                  class="mp-link"
+                  :href="info.profileUrl"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  <i class="icon-discogs" /> Discogs
+                </a>
+              </template>
+              <div v-else class="mp-state">No additional info.</div>
+            </div>
+          </div>
+        </div>
+      </transition>
+    </Teleport>
+  </span>
+</template>
+
+<script lang="ts" setup>
+import { useElementBounding, useEventListener, useWindowSize } from "@vueuse/core";
+import { computed, nextTick, ref } from "vue";
+
+import type { MemberInfo } from "@/@types/Artist";
+
+import { getDiscogsMemberInfo } from "@/helpers/discogs";
+
+const props = defineProps<{
+  discogsId?: null | number;
+  name: string;
+  thumbnail?: null | string;
+}>();
+
+const GAP = 12;
+const MARGIN = 8;
+const PANEL_WIDTH = 300;
+const CLOSE_DELAY = 120;
+const MAX_GROUPS = 8;
+
+const visible = ref(false);
+const loading = ref(false);
+const loaded = ref(false);
+const info = ref<MemberInfo | null>(null);
+const panelStyle = ref<Record<string, string>>({});
+
+const wrapperRef = ref<HTMLElement | null>(null);
+const panelRef = ref<HTMLElement | null>(null);
+let closeTimer: ReturnType<typeof setTimeout> | undefined;
+let loadTimer: ReturnType<typeof setTimeout> | undefined;
+
+const LOAD_DELAY = 250;
+
+const { height: viewportHeight, width: viewportWidth } = useWindowSize();
+const { height: wrapHeight, width: wrapWidth, x: wrapLeft, y: wrapTop } = useElementBounding(wrapperRef);
+const { height: panelHeight } = useElementBounding(panelRef);
+
+const image = computed(() => info.value?.image || props.thumbnail || null);
+
+const initials = computed(() =>
+  props.name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((w) => w[0].toUpperCase())
+    .join(""),
+);
+
+// Deterministic hue from name so each member gets a consistent color
+const avatarHue = computed(() => {
+  let hash = 0;
+  for (let i = 0; i < props.name.length; i++) hash = props.name.charCodeAt(i) + ((hash << 5) - hash);
+  return Math.abs(hash) % 360;
+});
+
+// Active groups first, current band(s) and self excluded already handled upstream
+const displayedGroups = computed(() => {
+  if (!info.value) return [];
+  return [...info.value.groups]
+    .sort((a, b) => Number(b.active) - Number(a.active))
+    .slice(0, MAX_GROUPS);
+});
+
+function cancelClose(): void {
+  if (closeTimer) clearTimeout(closeTimer);
+}
+
+function cancelLoad(): void {
+  if (loadTimer) clearTimeout(loadTimer);
+}
+
+async function loadInfo(): Promise<void> {
+  if (loaded.value) return;
+  loaded.value = true;
+  loading.value = true;
+  info.value = await getDiscogsMemberInfo({ discogsId: props.discogsId ?? null, name: props.name });
+  loading.value = false;
+  nextTick(updatePosition);
+}
+
+function open(): void {
+  cancelClose();
+  visible.value = true;
+  nextTick(updatePosition);
+  // Debounce the network lookup so sweeping the mouse over the list does not
+  // fire a Discogs request per member
+  if (!loaded.value) {
+    cancelLoad();
+    loadTimer = setTimeout(loadInfo, LOAD_DELAY);
+  }
+}
+
+function scheduleClose(): void {
+  cancelClose();
+  cancelLoad();
+  closeTimer = setTimeout(() => {
+    visible.value = false;
+  }, CLOSE_DELAY);
+}
+
+function updatePosition(): void {
+  const vpW = viewportWidth.value || window.innerWidth;
+  const vpH = viewportHeight.value || window.innerHeight;
+
+  // Prefer the right side; flip left when there is not enough room
+  const spaceRight = vpW - (wrapLeft.value + wrapWidth.value) - GAP;
+  const left
+    = spaceRight >= PANEL_WIDTH + MARGIN
+      ? wrapLeft.value + wrapWidth.value + GAP
+      : Math.max(wrapLeft.value - PANEL_WIDTH - GAP, MARGIN);
+
+  const panelH = panelHeight.value || 0;
+  const desiredTop = wrapTop.value + wrapHeight.value / 2 - panelH / 2;
+  const top = Math.min(Math.max(desiredTop, MARGIN), Math.max(vpH - panelH - MARGIN, MARGIN));
+
+  panelStyle.value = {
+    left: `${left}px`,
+    top: `${top}px`,
+    width: `${PANEL_WIDTH}px`,
+  };
+}
+
+useEventListener(window, "scroll", () => visible.value && updatePosition(), { capture: true });
+useEventListener(window, "resize", () => visible.value && updatePosition());
+</script>
+
+<style lang="scss">
+/* Unscoped: the popover is teleported to <body> */
+.member-popover {
+  background: var(--bg-color-dark);
+  border: 1px solid var(--bg-color-lighter);
+  border-radius: 0.5rem;
+  box-shadow: 0 0.5rem 1.5rem rgb(0 0 0 / 45%);
+  color: var(--font-color-light);
+  overflow: hidden;
+  padding: 0;
+  position: fixed;
+  z-index: 10000;
+}
+
+.member-popover .mp-layout {
+  display: flex;
+  min-height: 140px;
+}
+
+.member-popover .mp-photo-col {
+  flex-shrink: 0;
+  width: 100px;
+}
+
+.member-popover .mp-photo {
+  display: block;
+  height: 100%;
+  object-fit: cover;
+  width: 100%;
+}
+
+.member-popover .mp-photo-placeholder {
+  align-items: center;
+  display: flex;
+  height: 100%;
+  justify-content: center;
+}
+
+.member-popover .mp-initials {
+  color: rgb(255 255 255 / 80%);
+  font-size: 1.6rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  line-height: 1;
+  user-select: none;
+}
+
+.member-popover .mp-info-col {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 0;
+  padding: 0.75rem;
+}
+
+.member-popover .mp-name {
+  color: var(--font-color-default);
+  font-size: var(--font-size-base);
+}
+
+.member-popover .mp-realname {
+  font-size: var(--font-size-xs);
+  opacity: 0.6;
+}
+
+.member-popover .mp-section-title {
+  display: block;
+  font-size: var(--font-size-xs);
+  margin-bottom: 0.3rem;
+  opacity: 0.5;
+  text-transform: uppercase;
+}
+
+.member-popover .mp-groups {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  list-style: none;
+  margin: 0;
+  max-height: 11rem;
+  overflow-y: auto;
+  padding: 0;
+
+  li {
+    align-items: baseline;
+    display: flex;
+    font-size: var(--font-size-sm);
+    gap: 0.4rem;
+    justify-content: space-between;
+
+    &.former {
+      opacity: 0.55;
+    }
+  }
+}
+
+.member-popover .mp-group-name {
+  color: var(--font-color-default);
+}
+
+.member-popover .mp-former {
+  flex-shrink: 0;
+  font-size: var(--font-size-xs);
+  font-style: italic;
+  opacity: 0.7;
+}
+
+.member-popover .mp-link {
+  align-items: center;
+  color: var(--primary-color-light);
+  display: inline-flex;
+  font-size: var(--font-size-sm);
+  gap: 0.3rem;
+  margin-top: 0.6rem;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.member-popover .mp-state {
+  font-size: var(--font-size-sm);
+  opacity: 0.6;
+}
+
+.member-popover-enter-active,
+.member-popover-leave-active {
+  transition:
+    opacity 0.15s ease,
+    transform 0.15s ease;
+}
+
+.member-popover-enter-from,
+.member-popover-leave-to {
+  opacity: 0;
+  transform: translateY(4px);
+}
+</style>

--- a/src/components/artist/MemberTimeline.vue
+++ b/src/components/artist/MemberTimeline.vue
@@ -1,0 +1,332 @@
+<template>
+  <div v-if="rows.length > 0" class="member-timeline">
+    <h2 class="timeline-title">Members timeline</h2>
+
+    <div class="timeline-legend">
+      <span v-for="role in usedRoles" :key="role.label" class="legend-item">
+        <span class="legend-swatch" :style="{ backgroundColor: role.color }" />
+        {{ role.label }}
+      </span>
+    </div>
+
+    <div class="timeline-grid">
+      <!-- Year axis -->
+      <div class="axis-spacer" />
+      <div class="axis">
+        <span
+          v-for="tick in ticks"
+          :key="tick.year"
+          class="axis-tick"
+          :style="{ left: `${tick.left}%` }"
+        >
+          {{ tick.year }}
+        </span>
+      </div>
+
+      <!-- Member rows -->
+      <template v-for="row in rows" :key="row.id">
+        <div class="member-name" :class="{ 'is-active': !row.ended }">
+          {{ row.name }}
+        </div>
+        <div class="member-track">
+          <span
+            v-for="tick in ticks"
+            :key="`g-${tick.year}`"
+            class="grid-line"
+            :style="{ left: `${tick.left}%` }"
+          />
+          <span
+            class="member-bar"
+            :class="{ 'is-active': !row.ended, 'is-undated': !row.dated }"
+            :style="{ backgroundColor: row.color, left: `${row.left}%`, width: `${row.width}%` }"
+            :title="row.tooltip"
+          />
+        </div>
+      </template>
+    </div>
+
+    <p class="timeline-source">Source: Wikidata / MusicBrainz</p>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computed } from "vue";
+
+import { useArtist } from "@/views/artist/ArtistStore";
+
+interface AxisTick {
+  left: number;
+  year: number;
+}
+
+interface Role {
+  color: string;
+  keywords: string[];
+  label: string;
+}
+
+interface TimelineRow {
+  color: string;
+  dated: boolean;
+  ended: boolean;
+  id: string;
+  left: number;
+  name: string;
+  start: number;
+  tooltip: string;
+  width: number;
+}
+
+const MIN_BAR_WIDTH = 0.8;
+
+// Instrument -> role mapping, evaluated in order (bass before guitar matters)
+const ROLES: Role[] = [
+  { color: "#e2574c", keywords: ["vocal", "voice", "sing"], label: "Vocals" },
+  { color: "#e2a74c", keywords: ["bass"], label: "Bass" },
+  { color: "#4c9be2", keywords: ["guitar"], label: "Guitar" },
+  { color: "#9b59b6", keywords: ["keyboard", "piano", "organ", "synth"], label: "Keyboards" },
+  { color: "#2ecc71", keywords: ["drum", "percussion"], label: "Drums" },
+];
+const OTHER_ROLE: Role = { color: "#8a8a8a", keywords: [], label: "Other" };
+
+const artistStore = useArtist();
+const currentYear = new Date().getFullYear();
+
+const members = computed(() => artistStore.bandMembers);
+
+/**
+ * Resolve a member's primary role from their instruments, for bar coloring.
+ */
+function roleFor(instruments: string[]): Role {
+  const lowered = instruments.map((i) => i.toLowerCase());
+  for (const role of ROLES) {
+    if (lowered.some((instrument) => role.keywords.some((kw) => instrument.includes(kw)))) {
+      return role;
+    }
+  }
+  return OTHER_ROLE;
+}
+
+/**
+ * Convert a partial date (YYYY, YYYY-MM, YYYY-MM-DD) to a fractional year so
+ * months land at the right spot on the axis.
+ */
+function toYear(date: null | string): null | number {
+  if (!date) return null;
+  const [y, m] = date.split("-");
+  const year = parseInt(y, 10);
+  if (isNaN(year)) return null;
+  const month = m ? parseInt(m, 10) : 1;
+  return year + (isNaN(month) || month === 0 ? 0 : (month - 1) / 12);
+}
+
+const bounds = computed(() => {
+  const starts: number[] = [];
+  const ends: number[] = [];
+
+  members.value.forEach((member) => {
+    const start = toYear(member.begin);
+    if (start !== null) starts.push(start);
+    const end = toYear(member.end) ?? (member.ended ? start : currentYear);
+    if (end !== null) ends.push(end);
+  });
+
+  if (starts.length === 0) return null;
+
+  const min = Math.floor(Math.min(...starts));
+  const max = Math.ceil(Math.max(...ends, min));
+  return { max: Math.max(max, min + 1), min };
+});
+
+const rows = computed<TimelineRow[]>(() => {
+  const b = bounds.value;
+  if (!b) return [];
+
+  const span = b.max - b.min;
+
+  return members.value
+    .map((member) => {
+      const rawStart = toYear(member.begin);
+      const start = rawStart ?? b.min;
+      const end = toYear(member.end) ?? (member.ended ? start : currentYear);
+
+      const left = ((start - b.min) / span) * 100;
+      const width = Math.max(((end - start) / span) * 100, MIN_BAR_WIDTH);
+
+      const period = `${member.begin ?? "?"} – ${member.end ?? (member.ended ? "?" : "present")}`;
+      const instruments
+        = member.instruments.length > 0 ? ` (${member.instruments.join(", ")})` : "";
+
+      return {
+        color: roleFor(member.instruments).color,
+        dated: rawStart !== null,
+        ended: member.ended,
+        id: member.id,
+        left,
+        name: member.name,
+        start,
+        tooltip: rawStart !== null ? `${period}${instruments}` : `Dates unknown${instruments}`,
+        width,
+      };
+    })
+    .sort((a, b2) => a.start - b2.start);
+});
+
+const usedRoles = computed<Role[]>(() => {
+  const colors = new Set(rows.value.map((row) => row.color));
+  return [...ROLES, OTHER_ROLE].filter((role) => colors.has(role.color));
+});
+
+const ticks = computed<AxisTick[]>(() => {
+  const b = bounds.value;
+  if (!b) return [];
+
+  const span = b.max - b.min;
+  // Pick a readable step: ~6 ticks across the span
+  const rawStep = span / 6;
+  const niceSteps = [1, 2, 5, 10, 20, 25, 50];
+  const step = niceSteps.find((s) => s >= rawStep) ?? 50;
+
+  const result: AxisTick[] = [];
+  const first = Math.ceil(b.min / step) * step;
+  for (let year = first; year <= b.max; year += step) {
+    result.push({ left: ((year - b.min) / span) * 100, year });
+  }
+  return result;
+});
+</script>
+
+<style lang="scss" scoped>
+@use "@/assets/scss/mixins" as *;
+
+.member-timeline {
+  margin-bottom: 2.5rem;
+}
+
+.timeline-title {
+  @include font-bold;
+
+  border-bottom: 1px solid var(--bg-color-light);
+  color: var(--font-color-default);
+  font-size: var(--font-size-xl);
+  margin-bottom: 1rem;
+  padding-bottom: 0.4rem;
+}
+
+.timeline-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 1rem;
+  margin-bottom: 1.2rem;
+}
+
+.legend-item {
+  align-items: center;
+  color: var(--font-color-light);
+  display: inline-flex;
+  font-size: var(--font-size-xs);
+  gap: 0.4rem;
+}
+
+.legend-swatch {
+  border-radius: 0.2rem;
+  display: inline-block;
+  height: 0.7rem;
+  width: 0.7rem;
+}
+
+.timeline-grid {
+  align-items: center;
+  display: grid;
+  gap: 0.4rem 1rem;
+  grid-template-columns: minmax(7rem, max-content) 1fr;
+}
+
+.axis-spacer {
+  height: 1px;
+}
+
+.axis {
+  height: 1.2rem;
+  position: relative;
+}
+
+.axis-tick {
+  color: var(--font-color-light);
+  font-size: var(--font-size-xs);
+  opacity: 0.6;
+  position: absolute;
+  transform: translateX(-50%);
+  white-space: nowrap;
+}
+
+.member-name {
+  color: var(--font-color-light);
+  font-size: var(--font-size-sm);
+  overflow: hidden;
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  &.is-active {
+    @include font-bold;
+
+    color: var(--font-color-default);
+  }
+}
+
+.member-track {
+  height: 1.1rem;
+  position: relative;
+}
+
+.grid-line {
+  background-color: var(--bg-color-light);
+  bottom: 0;
+  opacity: 0.4;
+  position: absolute;
+  top: 0;
+  width: 1px;
+}
+
+.member-bar {
+  border-radius: 0.55rem;
+  display: block;
+  height: 0.7rem;
+  min-width: 0.7rem;
+  opacity: 0.65;
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  transition:
+    filter 0.2s ease,
+    opacity 0.2s ease;
+
+  &:hover {
+    filter: brightness(1.2);
+    opacity: 1;
+  }
+
+  &.is-active {
+    opacity: 1;
+  }
+
+  &.is-undated {
+    background-image: repeating-linear-gradient(
+      45deg,
+      rgb(255 255 255 / 25%) 0,
+      rgb(255 255 255 / 25%) 2px,
+      transparent 2px,
+      transparent 5px
+    );
+    opacity: 0.4;
+  }
+}
+
+.timeline-source {
+  color: var(--font-color-light);
+  font-size: var(--font-size-xs);
+  margin-top: 1rem;
+  opacity: 0.5;
+}
+</style>

--- a/src/components/artist/MemberTimeline.vue
+++ b/src/components/artist/MemberTimeline.vue
@@ -273,6 +273,18 @@ const ticks = computed<AxisTick[]>(() => {
     @include font-bold;
 
     color: var(--font-color-default);
+
+    &::after {
+      background-color: #2ecc71;
+      border-radius: 50%;
+      box-shadow: 0 0 5px rgb(46 204 113 / 80%);
+      content: "";
+      display: inline-block;
+      height: 7px;
+      margin-left: 0.4rem;
+      vertical-align: middle;
+      width: 7px;
+    }
   }
 }
 

--- a/src/components/artist/MemberTimeline.vue
+++ b/src/components/artist/MemberTimeline.vue
@@ -93,8 +93,6 @@ const OTHER_ROLE: Role = { color: "#8a8a8a", keywords: [], label: "Other" };
 const artistStore = useArtist();
 const currentYear = new Date().getFullYear();
 
-const members = computed(() => artistStore.bandMembers);
-
 /**
  * Resolve a member's primary role from their instruments, for bar coloring.
  */
@@ -125,7 +123,7 @@ const bounds = computed(() => {
   const starts: number[] = [];
   const ends: number[] = [];
 
-  members.value.forEach((member) => {
+  artistStore.bandMembers.forEach((member) => {
     const start = toYear(member.begin);
     if (start !== null) starts.push(start);
     const end = toYear(member.end) ?? (member.ended ? start : currentYear);
@@ -145,7 +143,7 @@ const rows = computed<TimelineRow[]>(() => {
 
   const span = b.max - b.min;
 
-  return members.value
+  return artistStore.bandMembers
     .map((member) => {
       const rawStart = toYear(member.begin);
       const start = rawStart ?? b.min;

--- a/src/components/artist/MemberTimeline.vue
+++ b/src/components/artist/MemberTimeline.vue
@@ -26,7 +26,7 @@
       <!-- Member rows -->
       <template v-for="row in rows" :key="row.id">
         <div class="member-name" :class="{ 'is-active': !row.ended }">
-          {{ row.name }}
+          <MemberPopover :name="row.name">{{ row.name }}</MemberPopover>
         </div>
         <div class="member-track">
           <span
@@ -52,6 +52,7 @@
 <script lang="ts" setup>
 import { computed } from "vue";
 
+import MemberPopover from "@/components/artist/MemberPopover.vue";
 import { useArtist } from "@/views/artist/ArtistStore";
 
 interface AxisTick {

--- a/src/components/artist/WikipediaTimeline.vue
+++ b/src/components/artist/WikipediaTimeline.vue
@@ -87,8 +87,8 @@ const MIN_SEG_WIDTH = 0.4;
 const artistStore = useArtist();
 const timeline = computed(() => artistStore.wikiTimeline);
 
-function yearLabel(value: number, till: number): string {
-  return value >= till - 0.3 ? "present" : `${Math.floor(value)}`;
+function yearLabel(value: number, till: number, openEnded: boolean): string {
+  return openEnded || value >= till - 0.3 ? "present" : `${Math.floor(value)}`;
 }
 
 const rows = computed<TimelineRow[]>(() => {
@@ -110,14 +110,14 @@ const rows = computed<TimelineRow[]>(() => {
             color: role?.color ?? "#8a8a8a",
             height: seg.thin ? "0.28rem" : "0.7rem",
             left: ((seg.from - tl.from) / span) * 100,
-            title: `${label} · ${Math.floor(seg.from)}–${yearLabel(seg.till, tl.till)}`,
+            title: `${label} · ${Math.floor(seg.from)}–${yearLabel(seg.till, tl.till, seg.openEnded)}`,
             width: Math.max(((seg.till - seg.from) / span) * 100, MIN_SEG_WIDTH),
             z: seg.thin ? 2 + index : 1,
           };
         });
 
       return {
-        active: segments.some((seg) => seg.title.endsWith("present")),
+        active: tl.segments.filter((seg) => seg.barId === bar.id).some((seg) => seg.openEnded),
         id: bar.id,
         name: bar.name,
         segments,
@@ -243,6 +243,18 @@ const ticks = computed<AxisTick[]>(() => {
     @include font-bold;
 
     color: var(--font-color-default);
+
+    &::after {
+      background-color: #2ecc71;
+      border-radius: 50%;
+      box-shadow: 0 0 5px rgb(46 204 113 / 80%);
+      content: "";
+      display: inline-block;
+      height: 7px;
+      margin-left: 0.4rem;
+      vertical-align: middle;
+      width: 7px;
+    }
   }
 }
 

--- a/src/components/artist/WikipediaTimeline.vue
+++ b/src/components/artist/WikipediaTimeline.vue
@@ -24,7 +24,7 @@
 
       <template v-for="row in rows" :key="row.id">
         <div class="member-name" :class="{ 'is-active': row.active }">
-          {{ row.name }}
+          <MemberPopover :name="row.name">{{ row.name }}</MemberPopover>
         </div>
         <div class="member-track">
           <span
@@ -58,6 +58,7 @@
 <script lang="ts" setup>
 import { computed } from "vue";
 
+import MemberPopover from "@/components/artist/MemberPopover.vue";
 import { useArtist } from "@/views/artist/ArtistStore";
 
 interface AxisTick {

--- a/src/components/artist/WikipediaTimeline.vue
+++ b/src/components/artist/WikipediaTimeline.vue
@@ -1,0 +1,279 @@
+<template>
+  <div v-if="timeline && rows.length > 0" class="wiki-timeline">
+    <h2 class="timeline-title">Members timeline</h2>
+
+    <div class="timeline-legend">
+      <span v-for="role in legend" :key="role.legend" class="legend-item">
+        <span class="legend-swatch" :style="{ backgroundColor: role.color }" />
+        {{ role.legend }}
+      </span>
+    </div>
+
+    <div class="timeline-grid">
+      <div class="axis-spacer" />
+      <div class="axis">
+        <span
+          v-for="tick in ticks"
+          :key="tick.year"
+          class="axis-tick"
+          :style="{ left: `${tick.left}%` }"
+        >
+          {{ tick.year }}
+        </span>
+      </div>
+
+      <template v-for="row in rows" :key="row.id">
+        <div class="member-name" :class="{ 'is-active': row.active }">
+          {{ row.name }}
+        </div>
+        <div class="member-track">
+          <span
+            v-for="event in events"
+            :key="`${row.id}-${event.left}`"
+            class="event-line"
+            :style="{ backgroundColor: event.color, left: `${event.left}%` }"
+            :title="event.title"
+          />
+          <span
+            v-for="(seg, index) in row.segments"
+            :key="index"
+            class="segment"
+            :style="{
+              backgroundColor: seg.color,
+              height: seg.height,
+              left: `${seg.left}%`,
+              width: `${seg.width}%`,
+              zIndex: seg.z,
+            }"
+            :title="seg.title"
+          />
+        </div>
+      </template>
+    </div>
+
+    <p class="timeline-source">Source: Wikipedia</p>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computed } from "vue";
+
+import { useArtist } from "@/views/artist/ArtistStore";
+
+interface AxisTick {
+  left: number;
+  year: number;
+}
+
+interface Segment {
+  color: string;
+  height: string;
+  left: number;
+  title: string;
+  width: number;
+  z: number;
+}
+
+interface TimelineRow {
+  active: boolean;
+  id: string;
+  name: string;
+  segments: Segment[];
+}
+
+const MIN_SEG_WIDTH = 0.4;
+
+const artistStore = useArtist();
+const timeline = computed(() => artistStore.wikiTimeline);
+
+function yearLabel(value: number, till: number): string {
+  return value >= till - 0.3 ? "present" : `${Math.floor(value)}`;
+}
+
+const rows = computed<TimelineRow[]>(() => {
+  const tl = timeline.value;
+  if (!tl) return [];
+
+  const span = tl.till - tl.from || 1;
+
+  return tl.bars
+    .map((bar) => {
+      // Wide (main) segments first, thin overlays painted on top
+      const segments = tl.segments
+        .filter((seg) => seg.barId === bar.id)
+        .sort((a, b) => Number(a.thin) - Number(b.thin))
+        .map((seg, index) => {
+          const role = tl.colors[seg.colorId];
+          const label = role?.legend ?? seg.colorId;
+          return {
+            color: role?.color ?? "#8a8a8a",
+            height: seg.thin ? "0.28rem" : "0.7rem",
+            left: ((seg.from - tl.from) / span) * 100,
+            title: `${label} · ${Math.floor(seg.from)}–${yearLabel(seg.till, tl.till)}`,
+            width: Math.max(((seg.till - seg.from) / span) * 100, MIN_SEG_WIDTH),
+            z: seg.thin ? 2 + index : 1,
+          };
+        });
+
+      return {
+        active: segments.some((seg) => seg.title.endsWith("present")),
+        id: bar.id,
+        name: bar.name,
+        segments,
+      };
+    })
+    .filter((row) => row.segments.length > 0);
+});
+
+const legend = computed(() => {
+  const tl = timeline.value;
+  if (!tl) return [];
+  const used = new Set([
+    ...tl.segments.map((seg) => seg.colorId),
+    ...tl.events.map((event) => event.colorId),
+  ]);
+  return Object.entries(tl.colors)
+    .filter(([id]) => used.has(id))
+    .map(([, role]) => role);
+});
+
+const events = computed(() => {
+  const tl = timeline.value;
+  if (!tl) return [];
+  const span = tl.till - tl.from || 1;
+  return tl.events.map((event) => ({
+    color: tl.colors[event.colorId]?.color ?? "#555",
+    left: ((event.date - tl.from) / span) * 100,
+    title: `${tl.colors[event.colorId]?.legend ?? "Release"} (${Math.floor(event.date)})`,
+  }));
+});
+
+const ticks = computed<AxisTick[]>(() => {
+  const tl = timeline.value;
+  if (!tl) return [];
+
+  const span = tl.till - tl.from || 1;
+  const rawStep = span / 6;
+  const niceSteps = [1, 2, 5, 10, 20, 25, 50];
+  const step = niceSteps.find((s) => s >= rawStep) ?? 50;
+
+  const result: AxisTick[] = [];
+  const first = Math.ceil(tl.from / step) * step;
+  for (let year = first; year <= tl.till; year += step) {
+    result.push({ left: ((year - tl.from) / span) * 100, year });
+  }
+  return result;
+});
+</script>
+
+<style lang="scss" scoped>
+@use "@/assets/scss/mixins" as *;
+
+.wiki-timeline {
+  margin-bottom: 2.5rem;
+}
+
+.timeline-title {
+  @include font-bold;
+
+  border-bottom: 1px solid var(--bg-color-light);
+  color: var(--font-color-default);
+  font-size: var(--font-size-xl);
+  margin-bottom: 1rem;
+  padding-bottom: 0.4rem;
+}
+
+.timeline-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 1rem;
+  margin-bottom: 1.2rem;
+}
+
+.legend-item {
+  align-items: center;
+  color: var(--font-color-light);
+  display: inline-flex;
+  font-size: var(--font-size-xs);
+  gap: 0.4rem;
+}
+
+.legend-swatch {
+  border-radius: 0.2rem;
+  display: inline-block;
+  height: 0.7rem;
+  width: 0.7rem;
+}
+
+.timeline-grid {
+  align-items: center;
+  display: grid;
+  gap: 0.35rem 1rem;
+  grid-template-columns: minmax(7rem, max-content) 1fr;
+}
+
+.axis-spacer {
+  height: 1px;
+}
+
+.axis {
+  height: 1.2rem;
+  position: relative;
+}
+
+.axis-tick {
+  color: var(--font-color-light);
+  font-size: var(--font-size-xs);
+  opacity: 0.6;
+  position: absolute;
+  transform: translateX(-50%);
+  white-space: nowrap;
+}
+
+.member-name {
+  color: var(--font-color-light);
+  font-size: var(--font-size-sm);
+  overflow: hidden;
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  &.is-active {
+    @include font-bold;
+
+    color: var(--font-color-default);
+  }
+}
+
+.member-track {
+  height: 1rem;
+  position: relative;
+}
+
+.event-line {
+  bottom: 0;
+  opacity: 0.25;
+  position: absolute;
+  top: 0;
+  width: 1px;
+}
+
+.segment {
+  border-radius: 0.2rem;
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  transition: filter 0.2s ease;
+
+  &:hover {
+    filter: brightness(1.25);
+  }
+}
+
+.timeline-source {
+  color: var(--font-color-light);
+  font-size: var(--font-size-xs);
+  margin-top: 1rem;
+  opacity: 0.5;
+}
+</style>

--- a/src/components/artist/WikipediaTimeline.vue
+++ b/src/components/artist/WikipediaTimeline.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="timeline && rows.length > 0" class="wiki-timeline">
+  <div v-if="artistStore.wikiTimeline && rows.length > 0" class="wiki-timeline">
     <h2 class="timeline-title">Members timeline</h2>
 
     <div class="timeline-legend">
@@ -85,23 +85,29 @@ interface TimelineRow {
 const MIN_SEG_WIDTH = 0.4;
 
 const artistStore = useArtist();
-const timeline = computed(() => artistStore.wikiTimeline);
 
 function yearLabel(value: number, till: number, openEnded: boolean): string {
   return openEnded || value >= till - 0.3 ? "present" : `${Math.floor(value)}`;
 }
 
 const rows = computed<TimelineRow[]>(() => {
-  const tl = timeline.value;
+  const tl = artistStore.wikiTimeline;
   if (!tl) return [];
 
   const span = tl.till - tl.from || 1;
 
+  const segsByBar = new Map<string, typeof tl.segments>();
+  for (const seg of tl.segments) {
+    const bucket = segsByBar.get(seg.barId);
+    if (bucket) bucket.push(seg);
+    else segsByBar.set(seg.barId, [seg]);
+  }
+
   return tl.bars
     .map((bar) => {
+      const barSegs = segsByBar.get(bar.id) ?? [];
       // Wide (main) segments first, thin overlays painted on top
-      const segments = tl.segments
-        .filter((seg) => seg.barId === bar.id)
+      const segments = barSegs
         .sort((a, b) => Number(a.thin) - Number(b.thin))
         .map((seg, index) => {
           const role = tl.colors[seg.colorId];
@@ -117,7 +123,7 @@ const rows = computed<TimelineRow[]>(() => {
         });
 
       return {
-        active: tl.segments.filter((seg) => seg.barId === bar.id).some((seg) => seg.openEnded),
+        active: barSegs.some((seg) => seg.openEnded),
         id: bar.id,
         name: bar.name,
         segments,
@@ -127,7 +133,7 @@ const rows = computed<TimelineRow[]>(() => {
 });
 
 const legend = computed(() => {
-  const tl = timeline.value;
+  const tl = artistStore.wikiTimeline;
   if (!tl) return [];
   const used = new Set([
     ...tl.segments.map((seg) => seg.colorId),
@@ -139,7 +145,7 @@ const legend = computed(() => {
 });
 
 const events = computed(() => {
-  const tl = timeline.value;
+  const tl = artistStore.wikiTimeline;
   if (!tl) return [];
   const span = tl.till - tl.from || 1;
   return tl.events.map((event) => ({
@@ -150,7 +156,7 @@ const events = computed(() => {
 });
 
 const ticks = computed<AxisTick[]>(() => {
-  const tl = timeline.value;
+  const tl = artistStore.wikiTimeline;
   if (!tl) return [];
 
   const span = tl.till - tl.from || 1;

--- a/src/components/search/SearchArtists.vue
+++ b/src/components/search/SearchArtists.vue
@@ -13,7 +13,12 @@
         @click="searchStore.reset()"
       >
         <Cover :images="artist.images" class="avatar" size="small" />
-        <div>{{ artist.name }}</div>
+        <div class="artist-name">
+          <div class="name">{{ artist.name }}</div>
+          <div v-if="artist.genres.length" class="genres">
+            <span v-for="genre in artist.genres" :key="genre" class="genre">{{ genre }}</span>
+          </div>
+        </div>
       </router-link>
     </template>
     <template v-else>No artist found</template>
@@ -70,6 +75,29 @@ const exactArtistSearched: ComputedRef<string | undefined> = computed(() => {
 
     @include search.search-item-hover;
 
+    .artist-name {
+      display: flex;
+      flex-direction: column;
+      gap: 0.3rem;
+
+    }
+
+    .genres {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.25rem;
+      margin-bottom: 0.15rem;
+
+      .genre {
+        background: var(--bg-color-lighter);
+        border-radius: 0.2rem;
+        color: var(--font-color-light);
+        font-size: 0.65rem;
+        padding: 0.1rem 0.35rem;
+        text-transform: capitalize;
+      }
+    }
+
     &.exact-search {
       background: var(--bg-color-lighter);
 
@@ -81,7 +109,6 @@ const exactArtistSearched: ComputedRef<string | undefined> = computed(() => {
         content: "";
         height: $size;
         left: 0;
-        position: "";
         position: absolute;
         top: 0;
         transform: translate(-20%, -20%);

--- a/src/components/search/SearchIndex.vue
+++ b/src/components/search/SearchIndex.vue
@@ -40,10 +40,10 @@ document.addEventListener("keydown", (keyboardEvent: KeyboardEvent) => {
   display: grid;
   font-size: var(--font-size-sm);
   gap: 2rem;
-  grid-template-columns: 0.6fr 1fr 0.8fr 0.8fr;
+  grid-template-columns: 0.9fr 1fr 0.8fr 0.8fr;
   justify-content: space-evenly;
   left: 0;
-  padding: 1rem;
+  padding: 0.5rem;
   right: 0;
   top: 100%;
   z-index: 999;

--- a/src/helpers/bandMembers.ts
+++ b/src/helpers/bandMembers.ts
@@ -1,0 +1,50 @@
+import type { BandMember } from "@/@types/Artist";
+
+/**
+ * Merge band members coming from two sources (e.g. Wikidata + MusicBrainz),
+ * de-duplicating by name and keeping the richest data available: dates from
+ * whichever source has them, and the union of instruments.
+ *
+ * Fields from `primary` win on conflict (pass the more trusted source first).
+ * @param primary - Preferred source (e.g. Wikidata)
+ * @param secondary - Fallback source (e.g. MusicBrainz)
+ * @returns Merged, de-duplicated members
+ */
+export function mergeBandMembers(primary: BandMember[], secondary: BandMember[]): BandMember[] {
+  const byName = new Map<string, BandMember>();
+
+  for (const member of [...primary, ...secondary]) {
+    const key = normalizeName(member.name);
+    if (!key) continue;
+    const existing = byName.get(key);
+    byName.set(key, existing ? combine(existing, member) : member);
+  }
+
+  return [...byName.values()];
+}
+
+/**
+ * Combine two records of the same member, keeping the richest fields.
+ */
+function combine(primary: BandMember, secondary: BandMember): BandMember {
+  return {
+    begin: primary.begin ?? secondary.begin,
+    end: primary.end ?? secondary.end,
+    ended: primary.ended || secondary.ended,
+    id: primary.id,
+    instruments: [...new Set([...primary.instruments, ...secondary.instruments])],
+    name: primary.name.length >= secondary.name.length ? primary.name : secondary.name,
+  };
+}
+
+/**
+ * Normalize a member name for cross-source matching (case/accent/punctuation-insensitive).
+ */
+function normalizeName(name: string): string {
+  return name
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "") // strip combining diacritics
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}

--- a/src/helpers/discogs.ts
+++ b/src/helpers/discogs.ts
@@ -1,8 +1,7 @@
 import ky from "ky";
 
-import { DiscogsArtist, DiscogsArtistReleasesResponse, DiscogsRelease } from "@/@types/Artist";
+import { DiscogsArtist, DiscogsArtistReleasesResponse, DiscogsRelease, MemberInfo } from "@/@types/Artist";
 import { normalizeString } from "@/helpers/helper";
-import { BEARDIFY_USER_AGENT } from "@/helpers/http";
 
 const DISCOGS_API_URL = "https://api.discogs.com/";
 const DISCOGS_TOKEN = import.meta.env.VITE_DISCOGS_TOKEN || "";
@@ -33,14 +32,15 @@ const TEXT_FORMATS: Array<{ pattern: RegExp; replacement: string }> = [
 ];
 
 /**
- * Creates a Discogs API client instance
+ * Creates a Discogs API client instance.
+ *
+ * Auth uses the `token` query param (added in `fetchFromDiscogs`) rather than an
+ * `Authorization` header: a custom header would trigger a CORS preflight that the
+ * Discogs API does not answer, blocking every browser request. The `User-Agent`
+ * header is likewise omitted because browsers forbid overriding it from fetch.
  */
 const discogsClient = ky.create({
   baseUrl: DISCOGS_API_URL,
-  headers: {
-    Authorization: `Discogs token=${DISCOGS_TOKEN}`,
-    "User-Agent": BEARDIFY_USER_AGENT,
-  },
   retry: {
     limit: 1,
     statusCodes: [429, 503],
@@ -56,6 +56,11 @@ const discogsClient = ky.create({
 export async function getDiscogsArtist(discogsId: string): Promise<DiscogsArtist | null> {
   return fetchFromDiscogs<DiscogsArtist>(`artists/${discogsId}`);
 }
+
+/**
+ * In-memory cache for member popover lookups (keyed by discogs id or normalized name)
+ */
+const memberInfoCache = new Map<string, MemberInfo | null>();
 
 /**
  * Get artist releases from Discogs
@@ -75,6 +80,47 @@ export async function getDiscogsArtistReleases(
     sort: "year",
     sort_order: "desc",
   });
+}
+
+/**
+ * Get condensed member info (image, real name, band history) for the member
+ * popover. Resolves by Discogs id when known, otherwise searches by name.
+ * Results are cached for the session.
+ * @param options - The member's Discogs id (preferred) and/or name
+ * @returns Promise resolving to MemberInfo or null when nothing is found
+ */
+export async function getDiscogsMemberInfo(options: {
+  discogsId?: null | number;
+  name: string;
+}): Promise<MemberInfo | null> {
+  const cacheKey = options.discogsId ? `id:${options.discogsId}` : `name:${normalizeString(options.name)}`;
+  const cached = memberInfoCache.get(cacheKey);
+  if (cached !== undefined) return cached;
+
+  const id = options.discogsId ?? (await searchDiscogsArtistId(options.name));
+  if (!id) {
+    memberInfoCache.set(cacheKey, null);
+    return null;
+  }
+
+  const artist = await getDiscogsArtist(id.toString());
+  if (!artist) {
+    memberInfoCache.set(cacheKey, null);
+    return null;
+  }
+
+  const info: MemberInfo = {
+    discogsId: id,
+    groups: (artist.groups ?? []).map((group) => ({
+      active: group.active,
+      name: cleanDiscogsName(group.name),
+    })),
+    image: artist.images?.[0]?.uri || artist.images?.[0]?.uri150 || null,
+    profileUrl: `https://www.discogs.com/artist/${id}`,
+    realName: artist.realname?.trim() || null,
+  };
+  memberInfoCache.set(cacheKey, info);
+  return info;
 }
 
 /**
@@ -115,10 +161,6 @@ export function parseDiscogsMarkup(text: string): string {
   return result;
 }
 
-/**
- * Processes Discogs releases to create a map of title -> release type (EP, Album)
- */
-
 export function processDiscogsReleases(releases: DiscogsRelease[]): Map<string, string> {
   const releaseMap = new Map<string, string>();
 
@@ -142,6 +184,36 @@ export function processDiscogsReleases(releases: DiscogsRelease[]): Map<string, 
   });
 
   return releaseMap;
+}
+
+/**
+ * Search Discogs for an artist by name and return the best matching id.
+ * @param name - The artist name to search for
+ * @returns Promise resolving to the Discogs artist id or null
+ */
+export async function searchDiscogsArtistId(name: string): Promise<null | number> {
+  const data = await fetchFromDiscogs<{ results: { id: number; title: string }[] }>("database/search", {
+    per_page: "5",
+    q: name,
+    type: "artist",
+  });
+
+  if (!data?.results?.length) return null;
+
+  const normalizedQuery = normalizeString(name);
+  const exact = data.results.find((result) => normalizeString(cleanDiscogsName(result.title)) === normalizedQuery);
+  return (exact ?? data.results[0]).id;
+}
+
+/**
+ * Processes Discogs releases to create a map of title -> release type (EP, Album)
+ */
+
+/**
+ * Strip the Discogs disambiguation suffix, e.g. "Exodus (6)" -> "Exodus".
+ */
+function cleanDiscogsName(name: string): string {
+  return name.replace(/\s*\(\d+\)$/, "");
 }
 
 /**
@@ -181,7 +253,9 @@ async function fetchFromDiscogs<T>(path: string, searchParams?: Record<string, s
   }
 
   try {
-    const response = await discogsClient.get(path, { searchParams });
+    const response = await discogsClient.get(path, {
+      searchParams: { ...searchParams, token: DISCOGS_TOKEN },
+    });
     return await response.json<T>();
   } catch {
     return null;

--- a/src/helpers/musicbrainz.ts
+++ b/src/helpers/musicbrainz.ts
@@ -1,5 +1,7 @@
 import ky from "ky";
 
+import type { BandMember } from "@/@types/Artist";
+
 /**
  * MusicBrainz API configuration
  */
@@ -42,9 +44,10 @@ interface MusicBrainzArea {
  * Interface for MusicBrainz artist relation
  */
 interface MusicBrainzArtistRelation {
+  artist?: MusicBrainzArtist;
   "attribute-ids": Record<string, string>;
   "attribute-values": Record<string, string>;
-  attributes: unknown[];
+  attributes: string[];
   begin: null | string;
   direction: string;
   end: null | string;
@@ -52,7 +55,7 @@ interface MusicBrainzArtistRelation {
   "source-credit": string;
   "target-credit": string;
   "target-type": string;
-  type: "allmusic" | "discogs" | "official homepage" | "wikidata" | string;
+  type: "allmusic" | "discogs" | "member of band" | "official homepage" | "wikidata" | string;
   "type-id": string;
   url?: {
     id: string;
@@ -114,6 +117,29 @@ const musicbrainzClient = ky.create({
 });
 
 /**
+ * Extracts band members (with active periods and instruments) from the
+ * "member of band" relations of a MusicBrainz group artist.
+ * @param artist - The full MusicBrainz artist (fetched with artist-rels)
+ * @returns Array of band members, empty when none
+ */
+export function extractBandMembers(artist: MusicBrainzArtist): BandMember[] {
+  if (!artist.relations) return [];
+
+  return artist.relations
+    .filter(
+      (rel) => rel.type === "member of band" && rel["target-type"] === "artist" && rel.artist,
+    )
+    .map((rel) => ({
+      begin: rel.begin,
+      end: rel.end,
+      ended: rel.ended,
+      id: rel.artist!.id,
+      instruments: Array.isArray(rel.attributes) ? rel.attributes : [],
+      name: rel.artist!.name,
+    }));
+}
+
+/**
  * Extracts external IDs (Discogs, Wikidata) from MusicBrainz relations
  */
 export function extractExternalIds(artistFull: MusicBrainzArtist): {
@@ -155,7 +181,7 @@ export function extractExternalIds(artistFull: MusicBrainzArtist): {
 }
 
 /**
- * Get Discogs ID and Wikidata ID from MusicBrainz artist
+ * Get Discogs ID, Wikidata ID and band members from MusicBrainz artist
  * @param musicbrainzId - The MusicBrainz ID of the artist
  * @returns Promise resolving to the MusicBrainzArtist object with relations, or null
  */
@@ -163,7 +189,7 @@ export async function getIdsFromMusicBrainz(
   musicbrainzId: string,
 ): Promise<MusicBrainzArtist | null> {
   return fetchFromMusicBrainz<MusicBrainzArtist>(`artist/${musicbrainzId}`, {
-    inc: "url-rels",
+    inc: "artist-rels+url-rels",
   });
 }
 

--- a/src/helpers/wikidata.ts
+++ b/src/helpers/wikidata.ts
@@ -1,6 +1,26 @@
+import type { BandMember } from "@/@types/Artist";
+
 import { BEARDIFY_USER_AGENT, http } from "@/helpers/http";
 
 const WIKIDATA_ENTITY_URL = "https://www.wikidata.org/wiki/Special:EntityData/";
+const WIKIDATA_API_URL = "https://www.wikidata.org/w/api.php";
+
+/**
+ * Wikidata property/item IDs used to extract band members from "has part(s)" (P527)
+ */
+const MEMBER_PROPERTIES = {
+  END_TIME: "P582",
+  HAS_PART: "P527",
+  HUMAN: "Q5",
+  INSTANCE_OF: "P31",
+  INSTRUMENT: "P1303",
+  START_TIME: "P580",
+};
+
+/**
+ * Max entities resolvable in a single wbgetentities call
+ */
+const WBGETENTITIES_CHUNK = 50;
 
 /**
  * Wikidata property IDs for music-related data
@@ -77,15 +97,8 @@ export interface WikipediaLanguage {
  * Interface for Wikidata claim
  */
 interface WikidataClaim {
-  mainsnak: {
-    datatype: string;
-    datavalue?: {
-      type: string;
-      value: { "numeric-id": number } | { id: string } | string;
-    };
-    property: string;
-    snaktype: string;
-  };
+  mainsnak: WikidataSnak;
+  qualifiers?: Record<string, WikidataSnak[]>;
   rank: string;
   type: string;
 }
@@ -101,6 +114,28 @@ interface WikidataEntity {
   sitelinks?: Record<string, { badges: string[]; site: string; title: string }>;
   type: string;
 }
+
+/**
+ * Interface for a Wikidata snak (main value or qualifier)
+ */
+interface WikidataSnak {
+  datatype?: string;
+  datavalue?: {
+    type: string;
+    value: WikidataValue;
+  };
+  property: string;
+  snaktype: string;
+}
+
+/**
+ * Possible value shapes returned by Wikidata
+ */
+type WikidataValue
+  = | { "numeric-id": number }
+    | { id: string }
+    | { precision: number; time: string }
+    | string;
 
 /**
  * Sections to exclude from Wikipedia content (multilingual)
@@ -322,6 +357,80 @@ export async function getWikidataArtist(entityId: string): Promise<null | Wikida
 }
 
 /**
+ * Get band members (with active periods and instruments) from a Wikidata
+ * band entity, using the "has part(s)" (P527) statements and their
+ * start/end time qualifiers. Member names and instruments are resolved
+ * through batched wbgetentities calls (no WDQS / SPARQL dependency).
+ * @param entityId - The Wikidata entity ID of the band (e.g., Q15920)
+ * @returns Promise resolving to band members, empty array when none
+ */
+export async function getWikidataBandMembers(entityId: string): Promise<BandMember[]> {
+  try {
+    const response = await wikidataClient.get(`${WIKIDATA_ENTITY_URL}${entityId}.json`);
+    const data = await response.json<{ entities: Record<string, WikidataEntity> }>();
+    const statements = data.entities[entityId]?.claims?.[MEMBER_PROPERTIES.HAS_PART];
+    if (!statements?.length) return [];
+
+    // Extract member Q-ids and their start/end periods from the statements
+    const partials = statements
+      .map((statement) => {
+        const id = getSnakEntityId(statement.mainsnak);
+        if (!id) return null;
+        return {
+          begin: normalizeWikidataTime(getQualifierTime(statement, MEMBER_PROPERTIES.START_TIME)),
+          end: normalizeWikidataTime(getQualifierTime(statement, MEMBER_PROPERTIES.END_TIME)),
+          id,
+        };
+      })
+      .filter((part): part is { begin: null | string; end: null | string; id: string } => part !== null);
+
+    if (partials.length === 0) return [];
+
+    // Resolve member labels + instruments, dropping non-person parts (albums, logos…)
+    const memberEntities = await getWikidataEntities(
+      partials.map((part) => part.id),
+      "labels|claims",
+    );
+
+    const instrumentIds = new Set<string>();
+    const enriched = partials
+      .map((part) => {
+        const entity = memberEntities[part.id];
+        if (!entity || !isHumanOrUnknown(entity)) return null;
+        const instruments = getClaimEntityIds(entity, MEMBER_PROPERTIES.INSTRUMENT);
+        instruments.forEach((instrument) => instrumentIds.add(instrument));
+        return {
+          begin: part.begin,
+          end: part.end,
+          ended: part.end !== null,
+          id: part.id,
+          instrumentIds: instruments,
+          name: entity.labels?.en?.value || entity.labels?.fr?.value || part.id,
+        };
+      })
+      .filter((member) => member !== null);
+
+    if (enriched.length === 0) return [];
+
+    // Resolve instrument labels in a second batch
+    const instrumentLabels = await getWikidataEntities([...instrumentIds], "labels");
+
+    return enriched.map((member) => ({
+      begin: member.begin,
+      end: member.end,
+      ended: member.ended,
+      id: member.id,
+      instruments: member.instrumentIds
+        .map((instrument) => instrumentLabels[instrument]?.labels?.en?.value)
+        .filter((label): label is string => Boolean(label)),
+      name: member.name,
+    }));
+  } catch {
+    return [];
+  }
+}
+
+/**
  * Get Wikipedia article content (extract) from a Wikipedia URL
  * @param wikipediaUrl - The full Wikipedia URL
  * @returns Promise resolving to the article extract HTML or null
@@ -436,6 +545,15 @@ function cleanWikipediaHtml(html: string): string {
 }
 
 /**
+ * Extract all entity Q-ids referenced by a given property on an entity
+ */
+function getClaimEntityIds(entity: WikidataEntity, property: string): string[] {
+  return (entity.claims?.[property] ?? [])
+    .map((claim) => getSnakEntityId(claim.mainsnak))
+    .filter((id): id is string => id !== null);
+}
+
+/**
  * Extract string value from a Wikidata claim
  * @param claims - The claims object
  * @param propertyId - The property ID to extract
@@ -453,6 +571,55 @@ function getClaimStringValue(claims: Record<string, WikidataClaim[]>, propertyId
   }
 
   return null;
+}
+
+/**
+ * Read a time qualifier value (e.g. P580/P582) from a claim
+ */
+function getQualifierTime(claim: WikidataClaim, property: string): string | undefined {
+  const value = claim.qualifiers?.[property]?.[0]?.datavalue?.value;
+  return value && typeof value === "object" && "time" in value ? value.time : undefined;
+}
+
+/**
+ * Extract the referenced entity Q-id from a snak, or null when not an entity value
+ */
+function getSnakEntityId(snak: WikidataSnak): null | string {
+  if (snak.snaktype !== "value") return null;
+  const value = snak.datavalue?.value;
+  return value && typeof value === "object" && "id" in value ? value.id : null;
+}
+
+/**
+ * Batch-resolve Wikidata entities via wbgetentities (max 50 ids per request)
+ * @param ids - Entity Q-ids to resolve
+ * @param props - Comma-separated props (e.g. "labels|claims")
+ */
+async function getWikidataEntities(
+  ids: string[],
+  props: string,
+): Promise<Record<string, WikidataEntity>> {
+  const result: Record<string, WikidataEntity> = {};
+
+  for (let i = 0; i < ids.length; i += WBGETENTITIES_CHUNK) {
+    const chunk = ids.slice(i, i + WBGETENTITIES_CHUNK);
+    if (chunk.length === 0) continue;
+
+    const params = new URLSearchParams({
+      action: "wbgetentities",
+      format: "json",
+      ids: chunk.join("|"),
+      languages: "en|fr",
+      origin: "*",
+      props,
+    });
+
+    const response = await wikidataClient.get(`${WIKIDATA_API_URL}?${params.toString()}`);
+    const data = await response.json<{ entities?: Record<string, WikidataEntity> }>();
+    if (data.entities) Object.assign(result, data.entities);
+  }
+
+  return result;
 }
 
 /**
@@ -534,6 +701,33 @@ function getWikipediaUrl(
   }
 
   return null;
+}
+
+/**
+ * Whether an entity is a human (P31=Q5) or has no explicit type.
+ * Used to drop non-person "has part" values such as albums or logos.
+ */
+function isHumanOrUnknown(entity: WikidataEntity): boolean {
+  const types = getClaimEntityIds(entity, MEMBER_PROPERTIES.INSTANCE_OF);
+  return types.length === 0 || types.includes(MEMBER_PROPERTIES.HUMAN);
+}
+
+/**
+ * Normalize a Wikidata time value (e.g. "+1981-10-28T00:00:00Z") to a partial
+ * date string (YYYY, YYYY-MM or YYYY-MM-DD), dropping unknown month/day "00".
+ */
+function normalizeWikidataTime(time: string | undefined): null | string {
+  if (!time) return null;
+  const match = time.match(/^[+-]?(\d{4})-(\d{2})-(\d{2})/);
+  if (!match) return null;
+
+  const [, year, month, day] = match;
+  let result = year;
+  if (month !== "00") {
+    result += `-${month}`;
+    if (day !== "00") result += `-${day}`;
+  }
+  return result;
 }
 
 /**

--- a/src/helpers/wikipediaTimeline.ts
+++ b/src/helpers/wikipediaTimeline.ts
@@ -107,9 +107,12 @@ export async function getWikipediaTimeline(wikipediaUrl: string): Promise<null |
     if (!wikitext) return null;
 
     const block = extractTimelineBlock(wikitext);
-    if (!block) return null;
+    if (block) {
+      const result = parseEasyTimeline(block);
+      if (result) return result;
+    }
 
-    return parseEasyTimeline(block);
+    return parseBandMembersSection(wikitext);
   } catch {
     return null;
   }
@@ -142,6 +145,89 @@ function extractTimelineBlock(wikitext: string): null | string {
     }
   }
   return wikitext.slice(contentStart, i - 2);
+}
+
+/**
+ * Fallback parser: extract member timelines from a Wikipedia "Band members" section
+ * when no EasyTimeline block is present. Handles lines like:
+ *   * [[Name|Display]] – instruments (2007–present)
+ *   * [[Name]] – guitar (2007–2022; died 2022)
+ */
+function parseBandMembersSection(wikitext: string): null | WikiTimeline {
+  const sectionStart = wikitext.search(/^==\s*(?:band\s+)?members?\s*==/im);
+  if (sectionStart === -1) return null;
+
+  const rest = wikitext.slice(sectionStart);
+  const nextSection = rest.match(/\n==(?!=)[^=]/);
+  const section = nextSection ? rest.slice(0, nextSection.index) : rest;
+
+  const COLOR_IDS = [
+    "blue", "green", "orange", "red", "purple", "teal", "coral", "yellow", "skyblue", "limegreen",
+  ] as const;
+
+  const bars: WikiTimelineBar[] = [];
+  const segments: WikiTimelineSegment[] = [];
+  const roleColorMap = new Map<string, string>();
+  let colorIdx = 0;
+  let minYear = Infinity;
+  let maxYear = -Infinity;
+
+  for (const rawLine of section.split("\n")) {
+    if (!rawLine.startsWith("*") || rawLine.startsWith("**")) continue;
+
+    const line = stripWikiMarkup(rawLine.slice(1).trim());
+
+    // Name – role (YYYY–YYYY) or (YYYY–present)
+    const dashIdx = line.search(/\s[–—-]\s/);
+    if (dashIdx === -1) continue;
+    const name = line.slice(0, dashIdx).trim();
+    const rest2 = line.slice(dashIdx + 1).trim();
+
+    const dateMatch = rest2.match(/\((\d{4})\s*[–—-]\s*(\d{4}|present)/i);
+    if (!dateMatch) continue;
+
+    const fromYear = parseInt(dateMatch[1]);
+    const openEnded = /present/i.test(dateMatch[2]);
+    const tillYear = openEnded ? todayFraction() : parseInt(dateMatch[2]);
+
+    if (isNaN(fromYear)) continue;
+
+    // Role: text between dash and opening paren, take primary instrument (before first comma)
+    const roleRaw = rest2.slice(0, rest2.indexOf("(")).trim();
+    const role = roleRaw.split(/[,(]/)[0].trim().toLowerCase() || "member";
+    const colorId = role.replace(/\W+/g, "_");
+
+    const barId = `m${bars.length}`;
+    const existing = bars.find((b) => b.name === name);
+    const actualBarId = existing ? existing.id : barId;
+    if (!existing) bars.push({ id: barId, name });
+
+    if (!roleColorMap.has(role)) {
+      roleColorMap.set(role, COLOR_IDS[colorIdx++ % COLOR_IDS.length]);
+    }
+
+    minYear = Math.min(minYear, fromYear);
+    maxYear = Math.max(maxYear, tillYear);
+
+    segments.push({ barId: actualBarId, colorId, from: fromYear, openEnded, thin: false, till: tillYear });
+  }
+
+  if (bars.length === 0 || segments.length === 0) return null;
+
+  const colors: Record<string, WikiTimelineColor> = {};
+  for (const [role, colorName] of roleColorMap) {
+    const colorId = role.replace(/\W+/g, "_");
+    colors[colorId] = { color: EASYTIMELINE_COLORS[colorName] ?? "#8a8a8a", legend: role };
+  }
+
+  return {
+    bars,
+    colors,
+    events: [],
+    from: Math.floor(minYear),
+    segments,
+    till: Math.ceil(maxYear),
+  };
 }
 
 /**
@@ -218,6 +304,20 @@ function parseEasyTimeline(block: string): null | WikiTimeline {
 function resolveColor(token: string): string {
   const name = token.split("(")[0].toLowerCase();
   return EASYTIMELINE_COLORS[name] ?? "#8a8a8a";
+}
+
+/**
+ * Strip Wikipedia wikitext markup, leaving plain text.
+ */
+function stripWikiMarkup(text: string): string {
+  return text
+    .replace(/<ref[^>]*>[\s\S]*?<\/ref>/g, "")
+    .replace(/<ref[^/]*\/>/g, "")
+    .replace(/\[\[([^\]|]+)\|([^\]]+)\]\]/g, "$2")
+    .replace(/\[\[([^\]]+)\]\]/g, "$1")
+    .replace(/'{2,3}/g, "")
+    .replace(/{{[^}]*}}/g, "")
+    .trim();
 }
 
 /**

--- a/src/helpers/wikipediaTimeline.ts
+++ b/src/helpers/wikipediaTimeline.ts
@@ -1,0 +1,261 @@
+import { http } from "@/helpers/http";
+
+/**
+ * A parsed EasyTimeline band-members graph (the "<timeline>" / "{{#tag:timeline}}"
+ * block found on many Wikipedia band articles). This is by far the richest member
+ * timeline source when present: per-member, per-role dated segments.
+ */
+export interface WikiTimeline {
+  /** Members in display order */
+  bars: WikiTimelineBar[];
+  /** Role id -> color + legend label */
+  colors: Record<string, WikiTimelineColor>;
+  /** Album / release markers (vertical lines) */
+  events: WikiTimelineEvent[];
+  /** Range start, fractional year */
+  from: number;
+  /** Per-member role segments */
+  segments: WikiTimelineSegment[];
+  /** Range end, fractional year */
+  till: number;
+}
+
+interface WikiTimelineBar {
+  id: string;
+  name: string;
+}
+
+interface WikiTimelineColor {
+  color: string;
+  legend: string;
+}
+
+interface WikiTimelineEvent {
+  colorId: string;
+  date: number;
+}
+
+interface WikiTimelineSegment {
+  barId: string;
+  colorId: string;
+  from: number;
+  /** true for thin overlay stripes (secondary roles, EasyTimeline width < default) */
+  thin: boolean;
+  till: number;
+}
+
+/**
+ * EasyTimeline named colors mapped to CSS values tuned for a dark UI.
+ */
+const EASYTIMELINE_COLORS: Record<string, string> = {
+  black: "#2b2b2b",
+  blue: "#3b7fe2",
+  brightgreen: "#5fd35f",
+  claret: "#9b2d4f",
+  coral: "#e2735a",
+  drabgreen: "#6b8e23",
+  gray: "#8a8a8a",
+  green: "#2e9e4f",
+  grey: "#8a8a8a",
+  lightorange: "#f3b96a",
+  limegreen: "#7ad13a",
+  magenta: "#c0399b",
+  oceanblue: "#2a6fb0",
+  orange: "#e2922e",
+  pink: "#f0a8be",
+  powderblue: "#9ec9e2",
+  purple: "#9b59b6",
+  red: "#e2574c",
+  redorange: "#e2562e",
+  skyblue: "#6fb7e2",
+  tan1: "#cdab7e",
+  tan2: "#e0c9a6",
+  teal: "#1f9e8a",
+  white: "#d8d8d8",
+  yellow: "#e2cb2e",
+};
+
+const DEFAULT_BAR_WIDTH = 13;
+
+/**
+ * Fetch and parse a Wikipedia band article's EasyTimeline members graph.
+ * @param wikipediaUrl - Full Wikipedia URL (any language; English usually has the graph)
+ * @returns The parsed timeline, or null when the article has no timeline block
+ */
+export async function getWikipediaTimeline(wikipediaUrl: string): Promise<null | WikiTimeline> {
+  try {
+    const urlMatch = wikipediaUrl.match(/https?:\/\/(\w+)\.wikipedia\.org\/wiki\/(.+)/);
+    if (!urlMatch) return null;
+
+    const [, lang, encodedTitle] = urlMatch;
+    const title = decodeURIComponent(encodedTitle);
+
+    const params = new URLSearchParams({
+      action: "parse",
+      format: "json",
+      formatversion: "2",
+      origin: "*",
+      page: title,
+      prop: "wikitext",
+    });
+
+    const response = await http.get(`https://${lang}.wikipedia.org/w/api.php?${params.toString()}`);
+    const data = await response.json<{ parse?: { wikitext?: string } }>();
+    const wikitext = data.parse?.wikitext;
+    if (!wikitext) return null;
+
+    const block = extractTimelineBlock(wikitext);
+    if (!block) return null;
+
+    return parseEasyTimeline(block);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extract the raw EasyTimeline DSL from either `<timeline>...</timeline>` or the
+ * parser-function form `{{#tag:timeline|...}}` (brace-aware for the latter).
+ */
+function extractTimelineBlock(wikitext: string): null | string {
+  const tagMatch = wikitext.match(/<timeline>([\s\S]*?)<\/timeline>/);
+  if (tagMatch) return tagMatch[1];
+
+  const marker = "{{#tag:timeline|";
+  const start = wikitext.indexOf(marker);
+  if (start === -1) return null;
+
+  let depth = 2;
+  let i = start + marker.length;
+  const contentStart = i;
+  while (i < wikitext.length && depth > 0) {
+    if (wikitext.startsWith("{{", i)) {
+      depth += 2;
+      i += 2;
+    } else if (wikitext.startsWith("}}", i)) {
+      depth -= 2;
+      i += 2;
+    } else {
+      i += 1;
+    }
+  }
+  return wikitext.slice(contentStart, i - 2);
+}
+
+/**
+ * Parse the EasyTimeline DSL into a structured, render-ready model.
+ */
+function parseEasyTimeline(block: string): null | WikiTimeline {
+  const lines = block.split("\n");
+
+  const formatMatch = block.match(/DateFormat\s*=\s*(\S+)/);
+  const format = (formatMatch?.[1] ?? "mm/dd/yyyy").toLowerCase();
+
+  // Period range (fallback to a wide span if absent)
+  const periodFrom = block.match(/Period\s*=\s*from:(\S+)/)?.[1];
+  const periodTill = block.match(/Period[^\n]*till:(\S+)/)?.[1];
+  const range = { from: 2000, till: todayFraction() };
+  range.from = periodFrom ? (toFractionalYear(periodFrom, format, range) ?? range.from) : range.from;
+  range.till = periodTill ? (toFractionalYear(periodTill, format, range) ?? range.till) : range.till;
+
+  const colors: Record<string, WikiTimelineColor> = {};
+  const bars: WikiTimelineBar[] = [];
+  const segments: WikiTimelineSegment[] = [];
+  const events: WikiTimelineEvent[] = [];
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+
+    const colorMatch = line.match(/^id:(\S+)\s+value:(\S+(?:\([^)]*\))?)(?:\s+legend:(\S+))?/);
+    if (colorMatch) {
+      const [, id, value, legend] = colorMatch;
+      colors[id] = { color: resolveColor(value), legend: (legend ?? id).replace(/_/g, " ") };
+      continue;
+    }
+
+    const barMatch = line.match(/^bar:(\S+)\s+text:\s*"?([^"]+?)"?\s*$/);
+    if (barMatch && !line.includes("from:")) {
+      bars.push({ id: barMatch[1], name: barMatch[2].trim() });
+      continue;
+    }
+
+    const plotMatch = line.match(/^bar:(\S+)\s+from:(\S+)\s+till:(\S+)\s+color:(\S+)(?:\s+width:(\d+))?/);
+    if (plotMatch) {
+      const [, barId, from, till, colorId, width] = plotMatch;
+      const fromYear = toFractionalYear(from, format, range);
+      const tillYear = toFractionalYear(till, format, range);
+      if (fromYear !== null && tillYear !== null) {
+        segments.push({
+          barId,
+          colorId,
+          from: fromYear,
+          thin: width !== undefined && parseInt(width, 10) < DEFAULT_BAR_WIDTH,
+          till: tillYear,
+        });
+      }
+      continue;
+    }
+
+    const eventMatch = line.match(/^at:(\S+)\s+color:(\S+)/);
+    if (eventMatch) {
+      const date = toFractionalYear(eventMatch[1], format, range);
+      if (date !== null) events.push({ colorId: eventMatch[2], date });
+    }
+  }
+
+  if (bars.length === 0 || segments.length === 0) return null;
+
+  return { bars, colors, events, from: Math.floor(range.from), segments, till: Math.ceil(range.till) };
+}
+
+/**
+ * Resolve an EasyTimeline color token (e.g. "red", "gray(0.6)") to a CSS color.
+ */
+function resolveColor(token: string): string {
+  const name = token.split("(")[0].toLowerCase();
+  return EASYTIMELINE_COLORS[name] ?? "#8a8a8a";
+}
+
+/**
+ * Today as a fractional year.
+ */
+function todayFraction(): number {
+  const now = new Date();
+  return now.getFullYear() + now.getMonth() / 12 + (now.getDate() - 1) / 365;
+}
+
+/**
+ * Convert an EasyTimeline date token to a fractional year, honoring the
+ * DateFormat and the start/end keywords (and the {{#time}} = today value).
+ */
+function toFractionalYear(
+  token: string,
+  format: string,
+  range: { from: number; till: number },
+): null | number {
+  const value = token.trim();
+  if (value === "start") return range.from;
+  if (value === "end") return range.till;
+  if (value.includes("#time")) return todayFraction();
+
+  // Full date with separators, e.g. mm/dd/yyyy or dd/mm/yyyy
+  const parts = value.split(/[/.-]/).map((p) => parseInt(p, 10));
+  if (parts.some((n) => isNaN(n))) {
+    const yearOnly = parseInt(value, 10);
+    return isNaN(yearOnly) ? null : yearOnly;
+  }
+
+  if (parts.length === 1) return parts[0];
+
+  let year: number;
+  let month: number;
+  let day: number;
+  if (format.startsWith("dd")) {
+    [day, month, year] = parts;
+  } else if (format.startsWith("yyyy")) {
+    [year, month, day] = parts;
+  } else {
+    [month, day, year] = parts;
+  }
+  return year + (month - 1) / 12 + (day - 1) / 365;
+}

--- a/src/helpers/wikipediaTimeline.ts
+++ b/src/helpers/wikipediaTimeline.ts
@@ -39,6 +39,8 @@ interface WikiTimelineSegment {
   barId: string;
   colorId: string;
   from: number;
+  /** true when the segment has no explicit end (member still active) */
+  openEnded: boolean;
   /** true for thin overlay stripes (secondary roles, EasyTimeline width < default) */
   thin: boolean;
   till: number;
@@ -184,11 +186,13 @@ function parseEasyTimeline(block: string): null | WikiTimeline {
       const [, barId, from, till, colorId, width] = plotMatch;
       const fromYear = toFractionalYear(from, format, range);
       const tillYear = toFractionalYear(till, format, range);
+      const openEnded = till === "end" || till.includes("#time");
       if (fromYear !== null && tillYear !== null) {
         segments.push({
           barId,
           colorId,
           from: fromYear,
+          openEnded,
           thin: width !== undefined && parseInt(width, 10) < DEFAULT_BAR_WIDTH,
           till: tillYear,
         });

--- a/src/views/artist/ArtistStore.ts
+++ b/src/views/artist/ArtistStore.ts
@@ -253,34 +253,37 @@ export const useArtist = defineStore("artist", {
       if (!wikidataArtistId) return;
       try {
         const { getWikidataArtist, getWikidataBandMembers } = await import("@/helpers/wikidata");
-        this.wikidataArtist = await getWikidataArtist(wikidataArtistId);
-
-        // Merge Wikidata members (often more precise dates) with the MusicBrainz
-        // fallback already in `bandMembers` (often richer instruments/lineup)
-        const wikidataMembers = await getWikidataBandMembers(wikidataArtistId);
         const { mergeBandMembers } = await import("@/helpers/bandMembers");
+
+        // Artist info and member list are independent — fetch in parallel
+        const [wikidataArtist, wikidataMembers] = await Promise.all([
+          getWikidataArtist(wikidataArtistId),
+          getWikidataBandMembers(wikidataArtistId),
+        ]);
+        this.wikidataArtist = wikidataArtist;
         this.bandMembers = mergeBandMembers(wikidataMembers, this.bandMembers);
 
-        // When the Wikipedia article has an EasyTimeline graph, it is far richer
-        // (per-member, per-role dated segments) — use it as the primary render
         const wikipediaUrl = this.wikidataArtist?.wikipediaUrl;
-        if (wikipediaUrl) {
-          const { getWikipediaTimeline } = await import("@/helpers/wikipediaTimeline");
-          this.wikiTimeline = await getWikipediaTimeline(wikipediaUrl);
-        }
+        const languages = this.wikidataArtist?.wikipediaLanguages ?? [];
+        const browserLang = navigator.language.split("-")[0];
+        const selectedLang
+          = languages.find((l) => l.code === browserLang)
+            || languages.find((l) => l.code === "en")
+            || languages[0];
 
-        const languages = this.wikidataArtist?.wikipediaLanguages || [];
-        if (languages.length > 0) {
-          const browserLang = navigator.language.split("-")[0];
-          const selectedLang
-            = languages.find((l) => l.code === browserLang)
-              || languages.find((l) => l.code === "en")
-              || languages[0];
+        // Timeline and extract both depend on wikidataArtist but are independent of each other
+        const timelinePromise = wikipediaUrl
+          ? import("@/helpers/wikipediaTimeline").then(({ getWikipediaTimeline }) =>
+              getWikipediaTimeline(wikipediaUrl),
+            )
+          : Promise.resolve(null);
+        const extractPromise = selectedLang ? getWikipediaExtract(selectedLang.url) : Promise.resolve(null);
 
-          if (selectedLang) {
-            this.wikipediaLanguage = selectedLang.code;
-            this.wikipediaExtract = await getWikipediaExtract(selectedLang.url);
-          }
+        const [newTimeline, extract] = await Promise.all([timelinePromise, extractPromise]);
+        this.wikiTimeline = newTimeline;
+        if (selectedLang) {
+          this.wikipediaLanguage = selectedLang.code;
+          this.wikipediaExtract = extract;
         }
       } catch {
         this.wikidataArtist = null;

--- a/src/views/artist/ArtistStore.ts
+++ b/src/views/artist/ArtistStore.ts
@@ -18,6 +18,7 @@ import {
 } from "@/helpers/discogs";
 import { normalizeString } from "@/helpers/helper";
 import {
+  extractBandMembers,
   extractExternalIds,
   getIdsFromMusicBrainz,
   searchMusicBrainzArtistId,
@@ -34,12 +35,14 @@ export const useArtist = defineStore("artist", {
     async clean() {
       this.activeTab = "discography";
       this.artist = defaultArtist;
+      this.bandMembers = [];
       this.discogsArtist = null;
       this.discogsId = null;
       this.discogsReleases = new Map();
       this.wikidataArtist = null;
       this.wikipediaExtract = null;
       this.wikipediaLanguage = "en";
+      this.wikiTimeline = null;
       this.topTracks = { tracks: [] };
       this.albums = [];
       this.albumsLive = [];
@@ -137,6 +140,7 @@ export const useArtist = defineStore("artist", {
 
     async getIds(artistName: string, spotifyId?: string) {
       this.musicbrainzArtist = null;
+      this.bandMembers = [];
       this.discogsId = null;
       this.wikidataId = null;
       this.wikidataArtist = null;
@@ -158,6 +162,7 @@ export const useArtist = defineStore("artist", {
         if (!artistFull) return;
 
         this.musicbrainzArtist = { ...artist, ...artistFull };
+        this.bandMembers = extractBandMembers(artistFull);
 
         const { discogsId, wikidataId } = extractExternalIds(artistFull);
 
@@ -247,8 +252,22 @@ export const useArtist = defineStore("artist", {
     async getWikidataArtist(wikidataArtistId: string): Promise<void> {
       if (!wikidataArtistId) return;
       try {
-        const { getWikidataArtist } = await import("@/helpers/wikidata");
+        const { getWikidataArtist, getWikidataBandMembers } = await import("@/helpers/wikidata");
         this.wikidataArtist = await getWikidataArtist(wikidataArtistId);
+
+        // Merge Wikidata members (often more precise dates) with the MusicBrainz
+        // fallback already in `bandMembers` (often richer instruments/lineup)
+        const wikidataMembers = await getWikidataBandMembers(wikidataArtistId);
+        const { mergeBandMembers } = await import("@/helpers/bandMembers");
+        this.bandMembers = mergeBandMembers(wikidataMembers, this.bandMembers);
+
+        // When the Wikipedia article has an EasyTimeline graph, it is far richer
+        // (per-member, per-role dated segments) — use it as the primary render
+        const wikipediaUrl = this.wikidataArtist?.wikipediaUrl;
+        if (wikipediaUrl) {
+          const { getWikipediaTimeline } = await import("@/helpers/wikipediaTimeline");
+          this.wikiTimeline = await getWikipediaTimeline(wikipediaUrl);
+        }
 
         const languages = this.wikidataArtist?.wikipediaLanguages || [];
         if (languages.length > 0) {
@@ -298,6 +317,7 @@ export const useArtist = defineStore("artist", {
     albums: [],
     albumsLive: [],
     artist: defaultArtist,
+    bandMembers: [],
     discogsArtist: null,
     discogsId: null,
     discogsReleases: new Map(),
@@ -312,5 +332,6 @@ export const useArtist = defineStore("artist", {
     wikidataId: null,
     wikipediaExtract: null,
     wikipediaLanguage: "en",
+    wikiTimeline: null,
   }),
 });


### PR DESCRIPTION
Parse Wikipedia EasyTimeline blocks and fetch Wikidata member records; merge with MusicBrainz members and render timelines via new MemberTimeline and WikipediaTimeline components.