### PR TITLE
feat(artist): add compilations section

### DIFF
--- a/src/@types/Artist.ts
+++ b/src/@types/Artist.ts
@@ -31,6 +31,7 @@ export interface ArtistPage {
   albumsLive: AlbumSimplified[];
   artist: Artist;
   bandMembers: BandMember[];
+  discographyLoading: boolean;
   discogsArtist: DiscogsArtist | null;
   discogsId: null | string;
   eps: AlbumSimplified[];
@@ -132,7 +133,7 @@ export interface DiscogsMember {
 
 export interface DiscogsRelease {
   artist: string;
-  format: string;
+  format: null | string;
   id: number;
   label: string;
   main_release: number;

--- a/src/@types/Artist.ts
+++ b/src/@types/Artist.ts
@@ -27,17 +27,18 @@ export interface Artist {
 export interface ArtistPage {
   activeTab: string;
   albums: AlbumSimplified[];
+  albumsCompilation: AlbumSimplified[];
   albumsLive: AlbumSimplified[];
   artist: Artist;
   bandMembers: BandMember[];
   discogsArtist: DiscogsArtist | null;
   discogsId: null | string;
-  discogsReleases: Map<string, string>;
   eps: AlbumSimplified[];
   followStatus: boolean | undefined;
   headerHeight: number;
   musicbrainzArtist: MusicBrainzArtist | null;
   relatedArtists: RelatedArtists;
+  releaseTypes: Map<string, string>;
   scrolledDown: boolean;
   singles: AlbumSimplified[];
   timelineLoading: boolean;

--- a/src/components/artist/ArtistInfo.vue
+++ b/src/components/artist/ArtistInfo.vue
@@ -4,8 +4,8 @@
       <div v-if="artistStore.timelineLoading" class="timeline-loader">
         <LoadingDots size="small" />
       </div>
-      <WikipediaTimeline v-else-if="artistStore.wikiTimeline" />
-      <MemberTimeline v-else-if="artistStore.bandMembers.length > 0" />
+      <WikipediaTimeline v-else-if="artistStore.wikiTimeline && !isSoloArtist" />
+      <MemberTimeline v-else-if="artistStore.bandMembers.length > 0 && !isSoloArtist" />
 
       <div v-if="hasBiography" class="info-section">
         <ArtistNavigation
@@ -62,6 +62,8 @@ interface WikipediaSection {
 const artistStore = useArtist();
 const wikipediaContentRef = ref<HTMLElement | null>(null);
 const wikipediaSections = ref<WikipediaSection[]>([]);
+
+const isSoloArtist = computed(() => artistStore.musicbrainzArtist?.type === "Person");
 
 const sanitizedWikipediaExtract = computed(() => {
   if (!artistStore.wikipediaExtract) return "";

--- a/src/components/artist/BlockAlbums.vue
+++ b/src/components/artist/BlockAlbums.vue
@@ -5,7 +5,7 @@
       Albums
     </div>
     <div class="albums">
-      <div v-for="(group, index) in albumGroups" :key="index">
+      <div v-for="group in albumGroups" :key="group.baseAlbum.id">
         <AlbumGroup :group="group" can-save clean-name />
       </div>
     </div>

--- a/src/components/artist/BlockAlbumsCompilation.vue
+++ b/src/components/artist/BlockAlbumsCompilation.vue
@@ -1,0 +1,36 @@
+<template>
+  <div v-if="artistStore.albumsCompilation.length" class="content-block">
+    <div :style="{ top: artistStore.headerHeight + 'px' }" class="heading sticky-heading">
+      <i class="icon-album" />
+      Compilations
+    </div>
+    <div class="albums">
+      <div v-for="(group, index) in compilationGroups" :key="index">
+        <AlbumGroup :group="group" can-save />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computed } from "vue";
+
+import AlbumGroup from "@/components/album/AlbumGroup.vue";
+import { groupAlbumVariants } from "@/helpers/groupAlbumVariants";
+import { useArtist } from "@/views/artist/ArtistStore";
+
+const artistStore = useArtist();
+
+const compilationGroups = computed(() => groupAlbumVariants(artistStore.albumsCompilation));
+</script>
+
+<style lang="scss" scoped>
+@use "@/assets/scss/colors" as colors;
+@use "@/assets/scss/responsive" as responsive;
+
+.albums {
+  display: grid;
+  gap: 1.2rem;
+  grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));
+}
+</style>

--- a/src/components/artist/BlockAlbumsCompilation.vue
+++ b/src/components/artist/BlockAlbumsCompilation.vue
@@ -5,7 +5,7 @@
       Compilations
     </div>
     <div class="albums">
-      <div v-for="(group, index) in compilationGroups" :key="index">
+      <div v-for="group in compilationGroups" :key="group.baseAlbum.id">
         <AlbumGroup :group="group" can-save />
       </div>
     </div>

--- a/src/components/artist/BlockAlbumsLive.vue
+++ b/src/components/artist/BlockAlbumsLive.vue
@@ -5,7 +5,7 @@
       Live albums
     </div>
     <div class="albums">
-      <div v-for="(group, index) in liveAlbumGroups" :key="index">
+      <div v-for="group in liveAlbumGroups" :key="group.baseAlbum.id">
         <AlbumGroup :group="group" can-save />
       </div>
     </div>

--- a/src/components/artist/BlockEps.vue
+++ b/src/components/artist/BlockEps.vue
@@ -5,7 +5,7 @@
       EP's
     </div>
     <div class="eps">
-      <div v-for="(group, index) in epGroups" :key="index">
+      <div v-for="group in epGroups" :key="group.baseAlbum.id">
         <AlbumGroup :group="group" can-save />
       </div>
     </div>

--- a/src/components/artist/BlockSingles.vue
+++ b/src/components/artist/BlockSingles.vue
@@ -5,12 +5,7 @@
       Singles
     </div>
     <div class="singles">
-      <div
-        v-for="(album, index) in artistStore.singles.sort(
-          (a, b) => parseInt(b.release_date, 10) - parseInt(a.release_date, 10),
-        )"
-        :key="index"
-      >
+      <div v-for="album in sortedSingles" :key="album.id">
         <SingleTrack :single="album" />
       </div>
     </div>
@@ -18,8 +13,17 @@
 </template>
 
 <script lang="ts" setup>
+import { computed } from "vue";
+
 import SingleTrack from "@/components/artist/SingleTrack.vue";
 import { useArtist } from "@/views/artist/ArtistStore";
 
 const artistStore = useArtist();
+
+// Copy before sorting: never mutate the store array during render.
+const sortedSingles = computed(() =>
+  [...artistStore.singles].sort(
+    (a, b) => parseInt(b.release_date, 10) - parseInt(a.release_date, 10),
+  ),
+);
 </script>

--- a/src/composables/useScrollRestore.ts
+++ b/src/composables/useScrollRestore.ts
@@ -77,7 +77,7 @@ export function useScrollRestore(
         // Settled: height stable for a while and we managed to reach the target
         // (or the page is simply shorter than the target — nothing more to do).
         const reached = Math.abs(el.scrollTop - target) <= 1;
-        if (stableFrames >= SETTLE_FRAMES && (reached || el.scrollHeight <= lastHeight)) {
+        if (stableFrames >= SETTLE_FRAMES && (reached || el.scrollHeight <= target)) {
           stopRestore();
           return;
         }

--- a/src/composables/useScrollRestore.ts
+++ b/src/composables/useScrollRestore.ts
@@ -1,25 +1,96 @@
-import { nextTick, onActivated, onDeactivated, onMounted, onUnmounted, type Ref } from "vue";
+import { onActivated, onDeactivated, onMounted, onUnmounted, type Ref } from "vue";
+
+// How long to keep pinning the saved position while content streams in.
+const RESTORE_TIMEOUT_MS = 3000;
+// Consider the layout settled once the scroll height stays unchanged this many
+// consecutive frames (~10 frames ≈ 160ms at 60fps).
+const SETTLE_FRAMES = 10;
 
 export function useScrollRestore(
   key: string,
   scrollRef: Ref<HTMLElement | null>,
 ): { onScroll: () => void; restoreScroll: () => void } {
   let lastScrollTop = 0;
+  let rafId = 0;
+  let isRestoring = false;
+  let detachAbort: (() => void) | null = null;
 
   function onScroll(): void {
+    // Ignore the programmatic scrollTop writes performed during restore. Late
+    // content shifts (reclassification, etc.) clamp scrollTop and would otherwise
+    // pollute the saved value, making it drift on every round-trip.
+    if (isRestoring) return;
     if (scrollRef.value) lastScrollTop = scrollRef.value.scrollTop;
+  }
+
+  function stopRestore(): void {
+    isRestoring = false;
+    cancelAnimationFrame(rafId);
+    detachAbort?.();
+    detachAbort = null;
   }
 
   function restoreScroll(): void {
     const saved = sessionStorage.getItem(key);
-    if (!saved || !scrollRef.value) return;
-    nextTick(() => {
-      if (!scrollRef.value) return;
-      const prev = scrollRef.value.style.scrollBehavior;
-      scrollRef.value.style.scrollBehavior = "auto";
-      scrollRef.value.scrollTop = parseInt(saved);
-      scrollRef.value.style.scrollBehavior = prev;
-    });
+    if (!saved) return;
+    const target = parseInt(saved);
+
+    stopRestore();
+    if (target <= 0) return;
+
+    isRestoring = true;
+    // Persist the intended position even if the user never scrolls again, so the
+    // next save doesn't overwrite it with 0.
+    lastScrollTop = target;
+
+    // Abort as soon as the user takes over — their intent wins over restoration.
+    const onUserInput = (): void => {
+      if (scrollRef.value) lastScrollTop = scrollRef.value.scrollTop;
+      stopRestore();
+    };
+    const events = ["wheel", "touchstart", "keydown", "pointerdown"] as const;
+    events.forEach((e) => window.addEventListener(e, onUserInput, { passive: true }));
+    detachAbort = (): void => events.forEach((e) => window.removeEventListener(e, onUserInput));
+
+    const start = performance.now();
+    let lastHeight = -1;
+    let stableFrames = 0;
+
+    // Content (albums, EPs, reclassified live/compilation lists…) keeps loading
+    // and resizing the page after navigation. Pin the target every frame until
+    // the height settles (layout stable) or we time out.
+    const apply = (): void => {
+      const el = scrollRef.value;
+      if (el) {
+        const prev = el.style.scrollBehavior;
+        el.style.scrollBehavior = "auto";
+        el.scrollTop = target;
+        el.style.scrollBehavior = prev;
+
+        if (el.scrollHeight === lastHeight) {
+          stableFrames += 1;
+        } else {
+          stableFrames = 0;
+          lastHeight = el.scrollHeight;
+        }
+
+        // Settled: height stable for a while and we managed to reach the target
+        // (or the page is simply shorter than the target — nothing more to do).
+        const reached = Math.abs(el.scrollTop - target) <= 1;
+        if (stableFrames >= SETTLE_FRAMES && (reached || el.scrollHeight <= lastHeight)) {
+          stopRestore();
+          return;
+        }
+      }
+
+      if (performance.now() - start < RESTORE_TIMEOUT_MS) {
+        rafId = requestAnimationFrame(apply);
+      } else {
+        stopRestore();
+      }
+    };
+
+    rafId = requestAnimationFrame(apply);
   }
 
   function saveScroll(): void {
@@ -27,7 +98,10 @@ export function useScrollRestore(
   }
 
   onDeactivated(saveScroll);
-  onUnmounted(saveScroll);
+  onUnmounted(() => {
+    stopRestore();
+    saveScroll();
+  });
   onActivated(restoreScroll);
   onMounted(restoreScroll);
 

--- a/src/composables/useScrollRestore.ts
+++ b/src/composables/useScrollRestore.ts
@@ -26,6 +26,7 @@ export function useScrollRestore(
   function stopRestore(): void {
     isRestoring = false;
     cancelAnimationFrame(rafId);
+    if (scrollRef.value) scrollRef.value.style.scrollBehavior = "";
     detachAbort?.();
     detachAbort = null;
   }
@@ -56,16 +57,17 @@ export function useScrollRestore(
     let lastHeight = -1;
     let stableFrames = 0;
 
+    // Disable smooth scrolling for the duration of the restore so every
+    // programmatic scrollTop write takes effect instantly. Restored in stopRestore.
+    if (scrollRef.value) scrollRef.value.style.scrollBehavior = "auto";
+
     // Content (albums, EPs, reclassified live/compilation lists…) keeps loading
     // and resizing the page after navigation. Pin the target every frame until
     // the height settles (layout stable) or we time out.
     const apply = (): void => {
       const el = scrollRef.value;
       if (el) {
-        const prev = el.style.scrollBehavior;
-        el.style.scrollBehavior = "auto";
         el.scrollTop = target;
-        el.style.scrollBehavior = prev;
 
         if (el.scrollHeight === lastHeight) {
           stableFrames += 1;

--- a/src/helpers/discogs.ts
+++ b/src/helpers/discogs.ts
@@ -232,10 +232,6 @@ export async function searchDiscogsArtistId(name: string): Promise<null | number
 }
 
 /**
- * Processes Discogs releases to create a map of title -> release type (EP, Album)
- */
-
-/**
  * Strip the Discogs disambiguation suffix, e.g. "Exodus (6)" -> "Exodus".
  */
 function cleanDiscogsName(name: string): string {

--- a/src/helpers/discogs.ts
+++ b/src/helpers/discogs.ts
@@ -161,6 +161,11 @@ export function parseDiscogsMarkup(text: string): string {
   return result;
 }
 
+/**
+ * Build a map of normalized release title -> type ("Live" | "Compilation" | "EP"
+ * | "Album") from Discogs master releases. Used to correct Spotify's unreliable
+ * grouping (it often files live records and EPs under plain albums).
+ */
 export function processDiscogsReleases(releases: DiscogsRelease[]): Map<string, string> {
   const releaseMap = new Map<string, string>();
 
@@ -170,7 +175,14 @@ export function processDiscogsReleases(releases: DiscogsRelease[]): Map<string, 
     if (release.type === "master" && release.format) {
       const format = release.format.toLowerCase();
 
-      if (format.includes("ep")) {
+      // Order matters: "Live"/"Compilation" are descriptors layered on top of an
+      // Album/EP format string (e.g. "CD, Album, Live"), so they must win over
+      // the generic Album/EP checks below.
+      if (format.includes("live")) {
+        releaseMap.set(normalizedTitle, "Live");
+      } else if (format.includes("compilation")) {
+        releaseMap.set(normalizedTitle, "Compilation");
+      } else if (format.includes("ep")) {
         releaseMap.set(normalizedTitle, "EP");
       } else if (
         format.includes("album")

--- a/src/helpers/discogs.ts
+++ b/src/helpers/discogs.ts
@@ -161,36 +161,50 @@ export function parseDiscogsMarkup(text: string): string {
   return result;
 }
 
+// Priority for type upgrades: Live beats Compilation beats EP beats Album.
+// Multiple editions of the same release can have different formats; we keep
+// the most specific type (e.g. a CD and a Live-DVD entry for the same title
+// → the title is classified as "Live").
+const RELEASE_TYPE_PRIORITY: Record<string, number> = {
+  Album: 1,
+  Compilation: 2,
+  EP: 3,
+  Live: 4,
+};
+
 /**
  * Build a map of normalized release title -> type ("Live" | "Compilation" | "EP"
- * | "Album") from Discogs master releases. Used to correct Spotify's unreliable
- * grouping (it often files live records and EPs under plain albums).
+ * | "Album") from Discogs release entries.
+ *
+ * Important: Discogs **master** entries always have `format: null`. The format
+ * string (e.g. "CD, Album, Live") only exists on per-edition **release** entries.
+ * We therefore scan `type === "release"` rows and group by normalized title,
+ * keeping the highest-priority type when multiple editions of the same title
+ * carry conflicting formats.
  */
 export function processDiscogsReleases(releases: DiscogsRelease[]): Map<string, string> {
   const releaseMap = new Map<string, string>();
 
   releases.forEach((release) => {
+    if (release.type !== "release" || !release.format) return;
+
     const normalizedTitle = normalizeString(release.title);
+    const format = release.format.toLowerCase();
+    let type: null | string = null;
 
-    if (release.type === "master" && release.format) {
-      const format = release.format.toLowerCase();
+    // "Live"/"Compilation" are layered descriptors (e.g. "CD, Album, Live"),
+    // so they must win over the generic Album/EP checks below.
+    if (format.includes("live")) type = "Live";
+    else if (format.includes("compilation")) type = "Compilation";
+    else if (format.includes("ep")) type = "EP";
+    else if (format.includes("album") || format.includes("lp") || format.includes("vinyl") || format.includes("cd")) {
+      type = "Album";
+    }
 
-      // Order matters: "Live"/"Compilation" are descriptors layered on top of an
-      // Album/EP format string (e.g. "CD, Album, Live"), so they must win over
-      // the generic Album/EP checks below.
-      if (format.includes("live")) {
-        releaseMap.set(normalizedTitle, "Live");
-      } else if (format.includes("compilation")) {
-        releaseMap.set(normalizedTitle, "Compilation");
-      } else if (format.includes("ep")) {
-        releaseMap.set(normalizedTitle, "EP");
-      } else if (
-        format.includes("album")
-        || format.includes("lp")
-        || format.includes("vinyl")
-        || format.includes("cd")
-      ) {
-        releaseMap.set(normalizedTitle, "Album");
+    if (type) {
+      const existing = releaseMap.get(normalizedTitle);
+      if (!existing || (RELEASE_TYPE_PRIORITY[type] ?? 0) > (RELEASE_TYPE_PRIORITY[existing] ?? 0)) {
+        releaseMap.set(normalizedTitle, type);
       }
     }
   });

--- a/src/helpers/helper.ts
+++ b/src/helpers/helper.ts
@@ -23,6 +23,7 @@ export function normalizeString(str: string): string {
   return str
     .toLowerCase()
     .replace(/[^\w\s]/g, "")
+    .replace(/\s+/g, " ")
     .trim();
 }
 

--- a/src/helpers/musicbrainz.ts
+++ b/src/helpers/musicbrainz.ts
@@ -3,6 +3,7 @@ import ky from "ky";
 import type { BandMember } from "@/@types/Artist";
 
 import { normalizeString } from "@/helpers/helper";
+import { sleep } from "@/helpers/sleep";
 
 /**
  * MusicBrainz API configuration
@@ -254,23 +255,30 @@ export async function getMusicBrainzReleaseGroups(
   musicbrainzId: string,
 ): Promise<MusicBrainzReleaseGroup[]> {
   const PAGE_SIZE = 100;
+  // MB anonymous rate limit is ~1 req/s. Wait between pages to avoid 429s that
+  // would cause fetchFromMusicBrainz to return null and break the loop early.
+  const PAGE_DELAY_MS = 600;
   const all: MusicBrainzReleaseGroup[] = [];
   let offset = 0;
 
-  // MusicBrainz caps page size at 100; loop until every group is fetched.
   for (;;) {
+    if (offset > 0) await sleep(PAGE_DELAY_MS);
+
     const data = await fetchFromMusicBrainz<MusicBrainzReleaseGroupBrowse>("release-group", {
       artist: musicbrainzId,
       limit: PAGE_SIZE,
       offset,
     });
 
-    const groups = data?.["release-groups"];
+    // null means a fetch/network error — stop, don't confuse with an empty last page.
+    if (data === null) break;
+
+    const groups = data["release-groups"];
     if (!groups?.length) break;
 
     all.push(...groups);
     offset += groups.length;
-    if (offset >= (data?.["release-group-count"] ?? all.length)) break;
+    if (offset >= data["release-group-count"]) break;
   }
 
   return all;

--- a/src/helpers/musicbrainz.ts
+++ b/src/helpers/musicbrainz.ts
@@ -2,6 +2,8 @@ import ky from "ky";
 
 import type { BandMember } from "@/@types/Artist";
 
+import { normalizeString } from "@/helpers/helper";
+
 /**
  * MusicBrainz API configuration
  */
@@ -83,6 +85,26 @@ interface MusicBrainzLifeSpan {
 }
 
 /**
+ * Interface for a MusicBrainz release-group (an "album" in the abstract sense,
+ * grouping all its editions). Carries the reliable type metadata Spotify lacks.
+ */
+interface MusicBrainzReleaseGroup {
+  "first-release-date"?: string;
+  id: string;
+  "primary-type": null | string;
+  "secondary-types": string[];
+  title: string;
+}
+
+/**
+ * Interface for the release-group browse response
+ */
+interface MusicBrainzReleaseGroupBrowse {
+  "release-group-count": number;
+  "release-groups": MusicBrainzReleaseGroup[];
+}
+
+/**
  * Interface for MusicBrainz tag
  */
 interface MusicBrainzTag {
@@ -115,6 +137,36 @@ const musicbrainzClient = ky.create({
   },
   timeout: 10000,
 });
+
+/**
+ * Build a map of normalized release title -> type ("Live" | "Compilation" | "EP"
+ * | "Album") from MusicBrainz release-groups.
+ *
+ * MusicBrainz is the most reliable source for this: "Live" and "Compilation" are
+ * explicit secondary types, independent of the primary type, so a live album is
+ * tagged primary "Album" + secondary "Live" (unlike Spotify, which mislabels
+ * them, and unlike Discogs, whose master entries expose no format string).
+ * @param groups - Release-groups from {@link getMusicBrainzReleaseGroups}
+ */
+export function buildReleaseTypeMap(groups: MusicBrainzReleaseGroup[]): Map<string, string> {
+  const map = new Map<string, string>();
+
+  groups.forEach((group) => {
+    const secondary = group["secondary-types"] ?? [];
+    const primary = group["primary-type"];
+    let type: null | string = null;
+
+    // Secondary types win: a live or compilation album keeps primary "Album".
+    if (secondary.includes("Live")) type = "Live";
+    else if (secondary.includes("Compilation")) type = "Compilation";
+    else if (primary === "EP") type = "EP";
+    else if (primary === "Album") type = "Album";
+
+    if (type) map.set(normalizeString(group.title), type);
+  });
+
+  return map;
+}
 
 /**
  * Extracts band members (with active periods and instruments) from the
@@ -191,6 +243,37 @@ export async function getIdsFromMusicBrainz(
   return fetchFromMusicBrainz<MusicBrainzArtist>(`artist/${musicbrainzId}`, {
     inc: "artist-rels+url-rels",
   });
+}
+
+/**
+ * Browse all release-groups of a MusicBrainz artist (paginated, 100 per page).
+ * @param musicbrainzId - The MusicBrainz ID of the artist
+ * @returns Promise resolving to every release-group, or an empty array on failure
+ */
+export async function getMusicBrainzReleaseGroups(
+  musicbrainzId: string,
+): Promise<MusicBrainzReleaseGroup[]> {
+  const PAGE_SIZE = 100;
+  const all: MusicBrainzReleaseGroup[] = [];
+  let offset = 0;
+
+  // MusicBrainz caps page size at 100; loop until every group is fetched.
+  for (;;) {
+    const data = await fetchFromMusicBrainz<MusicBrainzReleaseGroupBrowse>("release-group", {
+      artist: musicbrainzId,
+      limit: PAGE_SIZE,
+      offset,
+    });
+
+    const groups = data?.["release-groups"];
+    if (!groups?.length) break;
+
+    all.push(...groups);
+    offset += groups.length;
+    if (offset >= (data?.["release-group-count"] ?? all.length)) break;
+  }
+
+  return all;
 }
 
 /**

--- a/src/helpers/useCleanAlbums.ts
+++ b/src/helpers/useCleanAlbums.ts
@@ -57,9 +57,18 @@ const COMPILATION_KEYWORDS = [
   "very best of",
   "(demos)",
   "collection of",
+  "'s classic",
+  "happy holidays",
+  "remixed",
+  "from the original",
 ];
 
-const compilationAlbumRegex = new RegExp(`(${COMPILATION_KEYWORDS.map((k) => k.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|")})`);
+const COMPILATION_SPECIAL_PATTERNS = [
+  "mix\\]",
+  "mix\\)",
+];
+
+const compilationAlbumRegex = new RegExp(`(${[...COMPILATION_KEYWORDS, ...COMPILATION_SPECIAL_PATTERNS].join("|")})`);
 
 /**
  * Heuristic check: returns true if the album name suggests it is a compilation.

--- a/src/helpers/useCleanAlbums.ts
+++ b/src/helpers/useCleanAlbums.ts
@@ -36,6 +36,39 @@ export function isSingle(album: Album | AlbumSimplified | CurrentlyPlayingAlbum)
   return album.total_tracks < MIN_TRACKS_FOR_EP && album.album_type === "single";
 }
 
+// Keywords for compilation album detection
+const COMPILATION_KEYWORDS = [
+  "anniversary collection",
+  "anthology",
+  "b-sides",
+  "b sides",
+  "best of",
+  "chronicles",
+  "complete recordings",
+  "definitive collection",
+  "greatest hits",
+  "masterpieces",
+  "rarities",
+  "retrospective",
+  "singles collection",
+  "the collection",
+  "the essential",
+  "the very best",
+  "very best of",
+  "(demos)",
+  "collection of",
+];
+
+const compilationAlbumRegex = new RegExp(`(${COMPILATION_KEYWORDS.map((k) => k.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|")})`);
+
+/**
+ * Heuristic check: returns true if the album name suggests it is a compilation.
+ * @param albumName - Album title to test
+ */
+export function useCheckCompilationAlbum(albumName: string): boolean {
+  return compilationAlbumRegex.test(albumName.toLowerCase().trim());
+}
+
 // Keywords for live album detection
 const LIVE_ALBUM_KEYWORDS = [
   "lost not forgotten archives",

--- a/src/helpers/useCleanAlbums.ts
+++ b/src/helpers/useCleanAlbums.ts
@@ -38,6 +38,8 @@ export function isSingle(album: Album | AlbumSimplified | CurrentlyPlayingAlbum)
 
 // Keywords for live album detection
 const LIVE_ALBUM_KEYWORDS = [
+  "lost not forgotten archives",
+  "chaos in motion",
   "live in",
   "live on",
   "live at",
@@ -67,6 +69,7 @@ const LIVE_ALBUM_KEYWORDS = [
 
 // Special patterns for live album detection
 const LIVE_ALBUM_SPECIAL_PATTERNS = [
+  "^live\\s",
   "\\(live",
   "\\[live",
   "\\- live",
@@ -92,7 +95,8 @@ const liveAlbumRegex = new RegExp(`(${[...LIVE_ALBUM_KEYWORDS, ...LIVE_ALBUM_SPE
  */
 export function useCheckLiveAlbum(albumName: string): boolean {
   const cleanedName = albumName.toLowerCase().trim();
-  return liveAlbumRegex.test(cleanedName) || cleanedName.split(" ").pop() === "live)";
+  const lastWord = cleanedName.split(" ").pop() ?? "";
+  return liveAlbumRegex.test(cleanedName) || lastWord === "live)" || lastWord === "live";
 }
 
 // Cache compiled regex for reissue album detection

--- a/src/views/album/AlbumPage.vue
+++ b/src/views/album/AlbumPage.vue
@@ -75,9 +75,11 @@ const route = useRoute();
 const currentTrack = computed(() => playerStore.playerState?.track_window.current_track);
 
 const pageRef = ref<HTMLElement | null>(null);
-const { onScroll } = useScrollRestore(`scroll-${route.path}`, pageRef);
+const { onScroll, restoreScroll } = useScrollRestore(`scroll-${route.path}`, pageRef);
 
-albumStore.clean().finally(() => albumStore.getAlbum(props.id));
+// No keep-alive: the page remounts on every navigation, so the scroll position
+// must be restored after the fresh content has loaded (height is stable then).
+albumStore.clean().finally(() => albumStore.getAlbum(props.id).finally(() => restoreScroll()));
 </script>
 
 <style lang="scss" scoped>

--- a/src/views/artist/ArtistPage.vue
+++ b/src/views/artist/ArtistPage.vue
@@ -7,22 +7,27 @@
     <Transition name="tab-fade" mode="out-in">
       <div v-if="artistStore.activeTab === 'discography'" key="discography" class="content">
         <div class="list">
-          <div
-            v-if="
-              !artistStore.albums.length &&
-              !artistStore.eps.length &&
-              !artistStore.singles.length &&
-              !artistStore.albumsLive.length &&
-              !artistStore.albumsCompilation.length
-            "
-          >
-            {{ artistStore.artist.name }} didn't release anything, it's a bit sad.
+          <div v-if="artistStore.discographyLoading" class="discography-loader">
+            <Loader />
           </div>
-          <BlockAlbums />
-          <BlockAlbumsLive />
-          <BlockAlbumsCompilation />
-          <BlockEps />
-          <BlockSingles />
+          <template v-else>
+            <div
+              v-if="
+                !artistStore.albums.length &&
+                !artistStore.eps.length &&
+                !artistStore.singles.length &&
+                !artistStore.albumsLive.length &&
+                !artistStore.albumsCompilation.length
+              "
+            >
+              {{ artistStore.artist.name }} didn't release anything, it's a bit sad.
+            </div>
+            <BlockAlbums />
+            <BlockAlbumsLive />
+            <BlockAlbumsCompilation />
+            <BlockEps />
+            <BlockSingles />
+          </template>
         </div>
         <div class="top">
           <TopTracks class="top-item" />
@@ -37,7 +42,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, watch } from "vue";
+import { nextTick, ref, watch } from "vue";
 import { useRoute } from "vue-router";
 
 import ArtistHeader from "@/components/artist/ArtistHeader.vue";
@@ -61,7 +66,7 @@ const artistStore = useArtist();
 const route = useRoute();
 
 const pageRef = ref<HTMLElement | null>(null);
-const { onScroll } = useScrollRestore(`scroll-${route.path}`, pageRef);
+const { onScroll, restoreScroll } = useScrollRestore(`scroll-${route.path}`, pageRef);
 
 let lastChangeTime = 0;
 
@@ -80,18 +85,37 @@ function handleScroll() {
   }
 }
 
-artistStore.clean().finally(() => {
+artistStore.clean().finally(async () => {
   const hashTab = location.hash.slice(1);
   if ((VALID_TABS as readonly string[]).includes(hashTab)) {
     artistStore.activeTab = hashTab as TabId;
   }
-  artistStore.getArtist(props.id);
   artistStore.getTopTracks(props.id);
-  artistStore.getAlbums(`artists/${props.id}/albums?include_groups=album&limit=50`);
-  artistStore.getCompilations(`artists/${props.id}/albums?include_groups=compilation&limit=50`);
   artistStore.getRelatedArtists(props.id);
-  artistStore.getSingles(props.id);
   artistStore.getFollowStatus(props.id);
+
+  if (artistStore.loadDiscographyCache(props.id)) {
+    // Lists ready immediately — fire getArtist in background for the info tab
+    // (wikidata, band members…) without blocking the discography display.
+    artistStore.getArtist(props.id);
+    await nextTick();
+    restoreScroll();
+    return;
+  }
+
+  try {
+    await Promise.all([
+      artistStore.getArtist(props.id),
+      artistStore.getAlbums(`artists/${props.id}/albums?include_groups=album&limit=50`),
+      artistStore.getCompilations(`artists/${props.id}/albums?include_groups=compilation&limit=50`),
+      artistStore.getSingles(props.id),
+    ]);
+    artistStore.reclassifyReleases();
+    artistStore.saveDiscographyCache(props.id);
+  } finally {
+    artistStore.discographyLoading = false;
+    restoreScroll();
+  }
 });
 
 watch(
@@ -209,6 +233,12 @@ watch(
 
 .loader {
   display: grid;
+  place-content: center;
+}
+
+.discography-loader {
+  display: grid;
+  padding: 4rem 0;
   place-content: center;
 }
 

--- a/src/views/artist/ArtistPage.vue
+++ b/src/views/artist/ArtistPage.vue
@@ -103,15 +103,24 @@ artistStore.clean().finally(async () => {
     return;
   }
 
+  // getArtist fetches Spotify info then drives MB/Discogs classification (slow pagination).
+  // Fire it in background so MB delays don't block the discography display.
+  // reclassifyReleases is called internally each time a classification source resolves.
+  const currentId = props.id;
+  void artistStore.getArtist(currentId).then(() => {
+    artistStore.reclassifyReleases();
+    if (artistStore.artist.id === currentId) {
+      artistStore.saveDiscographyCache(currentId);
+    }
+  });
+
   try {
     await Promise.all([
-      artistStore.getArtist(props.id),
       artistStore.getAlbums(`artists/${props.id}/albums?include_groups=album&limit=50`),
       artistStore.getCompilations(`artists/${props.id}/albums?include_groups=compilation&limit=50`),
       artistStore.getSingles(props.id),
     ]);
     artistStore.reclassifyReleases();
-    artistStore.saveDiscographyCache(props.id);
   } finally {
     artistStore.discographyLoading = false;
     restoreScroll();

--- a/src/views/artist/ArtistPage.vue
+++ b/src/views/artist/ArtistPage.vue
@@ -108,14 +108,15 @@ artistStore.clean().finally(async () => {
   // reclassifyReleases is called internally each time a classification source resolves.
   const currentId = props.id;
   const albumsPromise = Promise.all([
-    artistStore.getAlbums(`artists/${props.id}/albums?include_groups=album&limit=50`),
-    artistStore.getCompilations(`artists/${props.id}/albums?include_groups=compilation&limit=50`),
-    artistStore.getSingles(props.id),
+    artistStore.getAlbums(`artists/${currentId}/albums?include_groups=album&limit=50`),
+    artistStore.getCompilations(`artists/${currentId}/albums?include_groups=compilation&limit=50`),
+    artistStore.getSingles(currentId),
   ]);
 
   // Save cache only after both MB classification AND album data are loaded.
+  // reclassifyReleases is called internally by getReleaseGroups and getDiscogsReleases,
+  // so no explicit call needed here.
   void artistStore.getArtist(currentId).then(() => {
-    artistStore.reclassifyReleases();
     return albumsPromise;
   }).then(() => {
     if (artistStore.artist.id === currentId) {

--- a/src/views/artist/ArtistPage.vue
+++ b/src/views/artist/ArtistPage.vue
@@ -12,13 +12,15 @@
               !artistStore.albums.length &&
               !artistStore.eps.length &&
               !artistStore.singles.length &&
-              !artistStore.albumsLive.length
+              !artistStore.albumsLive.length &&
+              !artistStore.albumsCompilation.length
             "
           >
             {{ artistStore.artist.name }} didn't release anything, it's a bit sad.
           </div>
           <BlockAlbums />
           <BlockAlbumsLive />
+          <BlockAlbumsCompilation />
           <BlockEps />
           <BlockSingles />
         </div>
@@ -41,6 +43,7 @@ import { useRoute } from "vue-router";
 import ArtistHeader from "@/components/artist/ArtistHeader.vue";
 import ArtistInfo from "@/components/artist/ArtistInfo.vue";
 import BlockAlbums from "@/components/artist/BlockAlbums.vue";
+import BlockAlbumsCompilation from "@/components/artist/BlockAlbumsCompilation.vue";
 import BlockAlbumsLive from "@/components/artist/BlockAlbumsLive.vue";
 import BlockEps from "@/components/artist/BlockEps.vue";
 import BlockSingles from "@/components/artist/BlockSingles.vue";
@@ -85,6 +88,7 @@ artistStore.clean().finally(() => {
   artistStore.getArtist(props.id);
   artistStore.getTopTracks(props.id);
   artistStore.getAlbums(`artists/${props.id}/albums?include_groups=album&limit=50`);
+  artistStore.getCompilations(`artists/${props.id}/albums?include_groups=compilation&limit=50`);
   artistStore.getRelatedArtists(props.id);
   artistStore.getSingles(props.id);
   artistStore.getFollowStatus(props.id);

--- a/src/views/artist/ArtistPage.vue
+++ b/src/views/artist/ArtistPage.vue
@@ -107,19 +107,24 @@ artistStore.clean().finally(async () => {
   // Fire it in background so MB delays don't block the discography display.
   // reclassifyReleases is called internally each time a classification source resolves.
   const currentId = props.id;
+  const albumsPromise = Promise.all([
+    artistStore.getAlbums(`artists/${props.id}/albums?include_groups=album&limit=50`),
+    artistStore.getCompilations(`artists/${props.id}/albums?include_groups=compilation&limit=50`),
+    artistStore.getSingles(props.id),
+  ]);
+
+  // Save cache only after both MB classification AND album data are loaded.
   void artistStore.getArtist(currentId).then(() => {
     artistStore.reclassifyReleases();
+    return albumsPromise;
+  }).then(() => {
     if (artistStore.artist.id === currentId) {
       artistStore.saveDiscographyCache(currentId);
     }
   });
 
   try {
-    await Promise.all([
-      artistStore.getAlbums(`artists/${props.id}/albums?include_groups=album&limit=50`),
-      artistStore.getCompilations(`artists/${props.id}/albums?include_groups=compilation&limit=50`),
-      artistStore.getSingles(props.id),
-    ]);
+    await albumsPromise;
     artistStore.reclassifyReleases();
   } finally {
     artistStore.discographyLoading = false;

--- a/src/views/artist/ArtistStore.ts
+++ b/src/views/artist/ArtistStore.ts
@@ -29,7 +29,7 @@ import {
 import { notification } from "@/helpers/notifications";
 import { removeDuplicatesAlbums } from "@/helpers/removeDuplicate";
 import { cleanUrl } from "@/helpers/urls";
-import { isEP, useCheckLiveAlbum } from "@/helpers/useCleanAlbums";
+import { isEP, useCheckCompilationAlbum, useCheckLiveAlbum } from "@/helpers/useCleanAlbums";
 import { getWikipediaExtract } from "@/helpers/wikidata";
 
 interface DiscographySnapshot {
@@ -153,21 +153,22 @@ export const useArtist = defineStore("artist", {
         );
 
         const lives: AlbumSimplified[] = [];
+        const compilations: AlbumSimplified[] = [];
         const albums: AlbumSimplified[] = [];
 
         frenchMarketAlbums.forEach((album) => {
           if (useCheckLiveAlbum(album.name)) {
             lives.push(album);
+          } else if (useCheckCompilationAlbum(album.name)) {
+            compilations.push(album);
           } else {
             albums.push(album);
           }
         });
 
         this.albums = removeDuplicatesAlbums([...this.albums, ...albums]);
-        this.albumsLive = removeDuplicatesAlbums([
-          ...this.albumsLive,
-          ...lives,
-        ]);
+        this.albumsLive = removeDuplicatesAlbums([...this.albumsLive, ...lives]);
+        this.albumsCompilation = removeDuplicatesAlbums([...this.albumsCompilation, ...compilations]);
 
         if (data.next) await this.getAlbums(data.next);
 

--- a/src/views/artist/ArtistStore.ts
+++ b/src/views/artist/ArtistStore.ts
@@ -514,6 +514,16 @@ export const useArtist = defineStore("artist", {
       const promotedToLive: AlbumSimplified[] = [];
       const promotedToCompilation: AlbumSimplified[] = [];
       this.albums.forEach((album) => {
+        // Name heuristics take priority: they are curated and explicit.
+        // MB/Discogs is the fallback for albums the heuristic doesn't recognise.
+        if (useCheckLiveAlbum(album.name)) {
+          promotedToLive.push(album);
+          return;
+        }
+        if (useCheckCompilationAlbum(album.name)) {
+          promotedToCompilation.push(album);
+          return;
+        }
         switch (externalType(album)) {
           case "Compilation":
             promotedToCompilation.push(album);
@@ -532,8 +542,13 @@ export const useArtist = defineStore("artist", {
       const keptEps: AlbumSimplified[] = [];
       const promotedToAlbums: AlbumSimplified[] = [];
       this.eps.forEach((ep) => {
-        if (externalType(ep) === "Album") promotedToAlbums.push(ep);
-        else keptEps.push(ep);
+        if (useCheckLiveAlbum(ep.name)) {
+          promotedToLive.push(ep);
+        } else if (externalType(ep) === "Album") {
+          promotedToAlbums.push(ep);
+        } else {
+          keptEps.push(ep);
+        }
       });
 
       // Only reassign buckets that actually changed. This method runs after every

--- a/src/views/artist/ArtistStore.ts
+++ b/src/views/artist/ArtistStore.ts
@@ -32,12 +32,28 @@ import { cleanUrl } from "@/helpers/urls";
 import { isEP, useCheckLiveAlbum } from "@/helpers/useCleanAlbums";
 import { getWikipediaExtract } from "@/helpers/wikidata";
 
+interface DiscographySnapshot {
+  albums: AlbumSimplified[];
+  albumsCompilation: AlbumSimplified[];
+  albumsLive: AlbumSimplified[];
+  artist: Artist;
+  eps: AlbumSimplified[];
+  releaseTypes: Map<string, string>;
+  singles: AlbumSimplified[];
+  timestamp: number;
+}
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const CACHE_MAX_ENTRIES = 10;
+const discographyCache = new Map<string, DiscographySnapshot>();
+
 export const useArtist = defineStore("artist", {
   actions: {
     async clean() {
       this.activeTab = "discography";
       this.artist = defaultArtist;
       this.bandMembers = [];
+      this.discographyLoading = true;
       this.discogsArtist = null;
       this.discogsId = null;
       this.releaseTypes = new Map();
@@ -140,7 +156,7 @@ export const useArtist = defineStore("artist", {
         this.discogsArtist = artist;
 
         if (artist) {
-          this.getDiscogsReleases(discogsId);
+          await this.getDiscogsReleases(discogsId);
         }
       } catch {
         this.discogsArtist = null;
@@ -149,18 +165,25 @@ export const useArtist = defineStore("artist", {
 
     async getDiscogsReleases(discogsId: string) {
       try {
-        const releasesData = await getDiscogsArtistReleases(discogsId);
+        const firstPage = await getDiscogsArtistReleases(discogsId);
+        if (!firstPage) return;
 
-        if (releasesData) {
-          // MusicBrainz is the primary source and must win, so Discogs only fills
-          // in keys MusicBrainz didn't provide (existing entries take precedence).
-          this.releaseTypes = new Map([
-            ...processDiscogsReleases(releasesData.releases),
-            ...this.releaseTypes,
-          ]);
-          // Data may land after albums/EPs were classified — re-run.
-          this.reclassifyReleases();
+        const allReleases = [...firstPage.releases];
+
+        // Fetch a second page if available (200 releases total) so older albums
+        // — whose release entries are sorted by year desc — are also covered.
+        if (firstPage.pagination.pages > 1) {
+          const secondPage = await getDiscogsArtistReleases(discogsId, 2);
+          if (secondPage?.releases) allReleases.push(...secondPage.releases);
         }
+
+        // MusicBrainz is the primary source and must win, so Discogs only fills
+        // in keys MusicBrainz didn't provide (existing entries take precedence).
+        this.releaseTypes = new Map([
+          ...processDiscogsReleases(allReleases),
+          ...this.releaseTypes,
+        ]);
+        this.reclassifyReleases();
       } catch {
         // silent fail
       }
@@ -203,15 +226,16 @@ export const useArtist = defineStore("artist", {
         this.musicbrainzArtist = { ...artist, ...artistFull };
         this.bandMembers = extractBandMembers(artistFull);
 
-        // Primary source for Live/Compilation/EP classification.
-        this.getReleaseGroups(artist.id);
-
         const { discogsId, wikidataId } = extractExternalIds(artistFull);
+
+        // Release classification sources (Live/Compilation/EP). Run in parallel
+        // and await them so the discography is fully classified before display.
+        const classification: Promise<void>[] = [this.getReleaseGroups(artist.id)];
 
         // Update discogs fields: set or clear and fetch when present
         if (discogsId) {
           this.discogsId = discogsId;
-          this.getDiscogsArtist(discogsId);
+          classification.push(this.getDiscogsArtist(discogsId));
         } else {
           this.discogsId = null;
           this.discogsArtist = null;
@@ -226,6 +250,8 @@ export const useArtist = defineStore("artist", {
           this.wikipediaExtract = null;
           this.timelineLoading = false;
         }
+
+        await Promise.all(classification);
       } catch {
         this.discogsId = null;
         this.wikidataId = null;
@@ -271,8 +297,12 @@ export const useArtist = defineStore("artist", {
         const albumsToMove: AlbumSimplified[] = [];
 
         data.items.forEach((item) => {
-          const normalizedName = normalizeString(item.name);
-          const externalType = this.releaseTypes.get(normalizedName);
+          const norm = normalizeString(item.name);
+          let externalType = this.releaseTypes.get(norm);
+          if (externalType === undefined) {
+            const stripped = normalizeString(item.name.replace(/\s*[([][^)\]]*[)\]]\s*$/, ""));
+            if (stripped !== norm) externalType = this.releaseTypes.get(stripped);
+          }
 
           if (externalType === "EP") {
             onlyEps.push(item);
@@ -354,6 +384,23 @@ export const useArtist = defineStore("artist", {
       }
     },
 
+    loadDiscographyCache(artistId: string): boolean {
+      const snap = discographyCache.get(artistId);
+      if (!snap || Date.now() - snap.timestamp > CACHE_TTL_MS) {
+        discographyCache.delete(artistId);
+        return false;
+      }
+      this.albums = snap.albums;
+      this.albumsCompilation = snap.albumsCompilation;
+      this.albumsLive = snap.albumsLive;
+      this.artist = snap.artist;
+      this.eps = snap.eps;
+      this.releaseTypes = new Map(snap.releaseTypes);
+      this.singles = snap.singles;
+      this.discographyLoading = false;
+      return true;
+    },
+
     /**
      * Reconcile Spotify's grouping with external data (MusicBrainz release-groups
      * first, Discogs as fallback — see {@link releaseTypes}).
@@ -375,8 +422,14 @@ export const useArtist = defineStore("artist", {
     reclassifyReleases(): void {
       if (this.releaseTypes.size === 0) return;
 
-      const externalType = (album: AlbumSimplified): string | undefined =>
-        this.releaseTypes.get(normalizeString(album.name));
+      const externalType = (album: AlbumSimplified): string | undefined => {
+        const norm = normalizeString(album.name);
+        const direct = this.releaseTypes.get(norm);
+        if (direct !== undefined) return direct;
+        // Strip trailing parentheticals and retry: "Score (20th Anniversary)" → "Score"
+        const stripped = normalizeString(album.name.replace(/\s*[([][^)\]]*[)\]]\s*$/, ""));
+        return stripped !== norm ? this.releaseTypes.get(stripped) : undefined;
+      };
 
       const keptAlbums: AlbumSimplified[] = [];
       const promotedToEps: AlbumSimplified[] = [];
@@ -405,13 +458,48 @@ export const useArtist = defineStore("artist", {
         else keptEps.push(ep);
       });
 
-      this.albums = removeDuplicatesAlbums([...keptAlbums, ...promotedToAlbums]);
-      this.eps = removeDuplicatesAlbums([...keptEps, ...promotedToEps]);
-      this.albumsLive = removeDuplicatesAlbums([...this.albumsLive, ...promotedToLive]);
-      this.albumsCompilation = removeDuplicatesAlbums([
-        ...this.albumsCompilation,
-        ...promotedToCompilation,
-      ]);
+      // Only reassign buckets that actually changed. This method runs after every
+      // loader (and external data lands at different times), so skipping no-op
+      // assignments avoids needless re-renders that make the lists flicker.
+      if (promotedToEps.length || promotedToLive.length || promotedToCompilation.length || promotedToAlbums.length) {
+        this.albums = removeDuplicatesAlbums([...keptAlbums, ...promotedToAlbums]);
+      }
+      if (promotedToEps.length || promotedToAlbums.length) {
+        this.eps = removeDuplicatesAlbums([...keptEps, ...promotedToEps]);
+      }
+      if (promotedToLive.length) {
+        this.albumsLive = removeDuplicatesAlbums([...this.albumsLive, ...promotedToLive]);
+      }
+      if (promotedToCompilation.length) {
+        this.albumsCompilation = removeDuplicatesAlbums([
+          ...this.albumsCompilation,
+          ...promotedToCompilation,
+        ]);
+      }
+    },
+
+    saveDiscographyCache(artistId: string): void {
+      if (discographyCache.size >= CACHE_MAX_ENTRIES) {
+        let oldestKey = "";
+        let oldestTime = Infinity;
+        discographyCache.forEach((v, k) => {
+          if (v.timestamp < oldestTime) {
+            oldestTime = v.timestamp;
+            oldestKey = k;
+          }
+        });
+        if (oldestKey) discographyCache.delete(oldestKey);
+      }
+      discographyCache.set(artistId, {
+        albums: [...this.albums],
+        albumsCompilation: [...this.albumsCompilation],
+        albumsLive: [...this.albumsLive],
+        artist: { ...this.artist },
+        eps: [...this.eps],
+        releaseTypes: new Map(this.releaseTypes),
+        singles: [...this.singles],
+        timestamp: Date.now(),
+      });
     },
 
     async switchFollow(artistId: string) {
@@ -446,6 +534,7 @@ export const useArtist = defineStore("artist", {
     albumsLive: [],
     artist: defaultArtist,
     bandMembers: [],
+    discographyLoading: true,
     discogsArtist: null,
     discogsId: null,
     eps: [],

--- a/src/views/artist/ArtistStore.ts
+++ b/src/views/artist/ArtistStore.ts
@@ -74,11 +74,16 @@ function lookupReleaseType(
   let r = releaseTypes.get(norm);
   if (r !== undefined) return r;
 
-  // 2. Strip trailing parentheticals: "Score (20th Anniversary)" → "Score"
-  const stripped = normalizeString(name.replace(/\s*[([][^)\]]*[)\]]\s*$/, ""));
-  if (stripped !== norm) {
-    r = releaseTypes.get(stripped);
-    if (r !== undefined) return r;
+  // 2. Strip trailing edition markers: "Score (20th Anniversary)" → "Score"
+  // Skip year-ranges like "(81-82-83-84)" — they distinguish live/studio variants of the same base title.
+  const trailingParen = /\s*[([]([^)\]]*)[)\]]\s*$/;
+  const parenMatch = name.match(trailingParen);
+  if (parenMatch && !/^[\d\s\-/·]+$/.test(parenMatch[1])) {
+    const stripped = normalizeString(name.replace(trailingParen, ""));
+    if (stripped !== norm) {
+      r = releaseTypes.get(stripped);
+      if (r !== undefined) return r;
+    }
   }
 
   // 3. Compact (no spaces): handles slash/dot encoded differently ("cl dotcom" vs "cldotcom")
@@ -95,22 +100,23 @@ function lookupReleaseType(
     if (r !== undefined) return r;
   }
 
-  // 6. Spotify title is more specific (e.g. "Distant Lights Leicester" vs MB "Distant Lights")
-  //    Find longest MB key that is a proper word-boundary prefix of the Spotify norm.
+  // 6. Spotify title is more specific (e.g. "Distant Lights Leicester" vs MB "Distant Lights" → Live)
+  //    Only match non-Album types: a short studio title (e.g. MB "New Gold Dream" → Album) must not
+  //    shadow a longer live variant (e.g. Spotify "New Gold Dream 81828384") — that is step 7's job.
   let fwdType: string | undefined;
   let fwdLen = 0;
   for (const [mbKey, mbType] of releaseTypes) {
-    if (mbKey.length > fwdLen && norm.startsWith(mbKey + " ")) {
+    if (mbType !== "Album" && mbKey.length > fwdLen && norm.startsWith(mbKey + " ")) {
       fwdType = mbType;
       fwdLen = mbKey.length;
     }
   }
   if (fwdType !== undefined) return fwdType;
 
-  // 7. MB title is more specific (e.g. Spotify "The Gold" vs MB "The Gold Best of Convention 2017")
-  //    Return on first MB key that starts with the Spotify norm.
+  // 7. MB title is more specific (e.g. Spotify "The Gold" vs MB "The Gold Best of Convention 2017" → Live)
+  //    Only match non-Album types for the same reason as step 6.
   for (const [mbKey, mbType] of releaseTypes) {
-    if (mbKey.startsWith(norm + " ")) return mbType;
+    if (mbType !== "Album" && mbKey.startsWith(norm + " ")) return mbType;
   }
 
   return undefined;
@@ -207,10 +213,18 @@ export const useArtist = defineStore("artist", {
           album.available_markets.includes("FR"),
         );
 
-        this.albumsCompilation = removeDuplicatesAlbums([
-          ...this.albumsCompilation,
-          ...frenchMarketAlbums,
-        ]);
+        const lives: AlbumSimplified[] = [];
+        const compilations: AlbumSimplified[] = [];
+        frenchMarketAlbums.forEach((album) => {
+          if (useCheckLiveAlbum(album.name)) {
+            lives.push(album);
+          } else {
+            compilations.push(album);
+          }
+        });
+
+        this.albumsCompilation = removeDuplicatesAlbums([...this.albumsCompilation, ...compilations]);
+        this.albumsLive = removeDuplicatesAlbums([...this.albumsLive, ...lives]);
 
         if (data.next) await this.getCompilations(data.next);
 

--- a/src/views/artist/ArtistStore.ts
+++ b/src/views/artist/ArtistStore.ts
@@ -557,7 +557,7 @@ export const useArtist = defineStore("artist", {
       if (promotedToEps.length || promotedToLive.length || promotedToCompilation.length || promotedToAlbums.length) {
         this.albums = removeDuplicatesAlbums([...keptAlbums, ...promotedToAlbums]);
       }
-      if (promotedToEps.length || promotedToAlbums.length) {
+      if (promotedToEps.length || promotedToAlbums.length || promotedToLive.length) {
         this.eps = removeDuplicatesAlbums([...keptEps, ...promotedToEps]);
       }
       if (promotedToLive.length) {

--- a/src/views/artist/ArtistStore.ts
+++ b/src/views/artist/ArtistStore.ts
@@ -47,6 +47,75 @@ const CACHE_TTL_MS = 5 * 60 * 1000;
 const CACHE_MAX_ENTRIES = 10;
 const discographyCache = new Map<string, DiscographySnapshot>();
 
+interface ReleaseLookupMaps {
+  compact: Map<string, string>;
+  deArticled: Map<string, string>;
+}
+
+function buildReleaseLookupMaps(releaseTypes: Map<string, string>): ReleaseLookupMaps {
+  return {
+    compact: new Map([...releaseTypes.entries()].map(([k, v]) => [k.replace(/\s+/g, ""), v])),
+    deArticled: new Map(
+      [...releaseTypes.entries()]
+        .filter(([k]) => k.startsWith("the "))
+        .map(([k, v]) => [k.slice(4), v]),
+    ),
+  };
+}
+
+function lookupReleaseType(
+  name: string,
+  releaseTypes: Map<string, string>,
+  { compact, deArticled }: ReleaseLookupMaps,
+): string | undefined {
+  const norm = normalizeString(name);
+
+  // 1. Exact match
+  let r = releaseTypes.get(norm);
+  if (r !== undefined) return r;
+
+  // 2. Strip trailing parentheticals: "Score (20th Anniversary)" → "Score"
+  const stripped = normalizeString(name.replace(/\s*[([][^)\]]*[)\]]\s*$/, ""));
+  if (stripped !== norm) {
+    r = releaseTypes.get(stripped);
+    if (r !== undefined) return r;
+  }
+
+  // 3. Compact (no spaces): handles slash/dot encoded differently ("cl dotcom" vs "cldotcom")
+  r = compact.get(norm.replace(/\s+/g, ""));
+  if (r !== undefined) return r;
+
+  // 4. MB has "the", Spotify doesn't
+  r = deArticled.get(norm);
+  if (r !== undefined) return r;
+
+  // 5. Spotify has "the", MB doesn't
+  if (norm.startsWith("the ")) {
+    r = releaseTypes.get(norm.slice(4));
+    if (r !== undefined) return r;
+  }
+
+  // 6. Spotify title is more specific (e.g. "Distant Lights Leicester" vs MB "Distant Lights")
+  //    Find longest MB key that is a proper word-boundary prefix of the Spotify norm.
+  let fwdType: string | undefined;
+  let fwdLen = 0;
+  for (const [mbKey, mbType] of releaseTypes) {
+    if (mbKey.length > fwdLen && norm.startsWith(mbKey + " ")) {
+      fwdType = mbType;
+      fwdLen = mbKey.length;
+    }
+  }
+  if (fwdType !== undefined) return fwdType;
+
+  // 7. MB title is more specific (e.g. Spotify "The Gold" vs MB "The Gold Best of Convention 2017")
+  //    Return on first MB key that starts with the Spotify norm.
+  for (const [mbKey, mbType] of releaseTypes) {
+    if (mbKey.startsWith(norm + " ")) return mbType;
+  }
+
+  return undefined;
+}
+
 export const useArtist = defineStore("artist", {
   actions: {
     async clean() {
@@ -296,13 +365,12 @@ export const useArtist = defineStore("artist", {
         const onlyEps: AlbumSimplified[] = [];
         const albumsToMove: AlbumSimplified[] = [];
 
+        const maps = buildReleaseLookupMaps(this.releaseTypes);
+        const lookupType = (name: string): string | undefined =>
+          lookupReleaseType(name, this.releaseTypes, maps);
+
         data.items.forEach((item) => {
-          const norm = normalizeString(item.name);
-          let externalType = this.releaseTypes.get(norm);
-          if (externalType === undefined) {
-            const stripped = normalizeString(item.name.replace(/\s*[([][^)\]]*[)\]]\s*$/, ""));
-            if (stripped !== norm) externalType = this.releaseTypes.get(stripped);
-          }
+          const externalType = lookupType(item.name);
 
           if (externalType === "EP") {
             onlyEps.push(item);
@@ -422,14 +490,9 @@ export const useArtist = defineStore("artist", {
     reclassifyReleases(): void {
       if (this.releaseTypes.size === 0) return;
 
-      const externalType = (album: AlbumSimplified): string | undefined => {
-        const norm = normalizeString(album.name);
-        const direct = this.releaseTypes.get(norm);
-        if (direct !== undefined) return direct;
-        // Strip trailing parentheticals and retry: "Score (20th Anniversary)" → "Score"
-        const stripped = normalizeString(album.name.replace(/\s*[([][^)\]]*[)\]]\s*$/, ""));
-        return stripped !== norm ? this.releaseTypes.get(stripped) : undefined;
-      };
+      const maps = buildReleaseLookupMaps(this.releaseTypes);
+      const externalType = (album: AlbumSimplified): string | undefined =>
+        lookupReleaseType(album.name, this.releaseTypes, maps);
 
       const keptAlbums: AlbumSimplified[] = [];
       const promotedToEps: AlbumSimplified[] = [];

--- a/src/views/artist/ArtistStore.ts
+++ b/src/views/artist/ArtistStore.ts
@@ -18,9 +18,11 @@ import {
 } from "@/helpers/discogs";
 import { normalizeString } from "@/helpers/helper";
 import {
+  buildReleaseTypeMap,
   extractBandMembers,
   extractExternalIds,
   getIdsFromMusicBrainz,
+  getMusicBrainzReleaseGroups,
   searchMusicBrainzArtistId,
   searchMusicBrainzBySpotifyId,
 } from "@/helpers/musicbrainz";
@@ -38,7 +40,7 @@ export const useArtist = defineStore("artist", {
       this.bandMembers = [];
       this.discogsArtist = null;
       this.discogsId = null;
-      this.discogsReleases = new Map();
+      this.releaseTypes = new Map();
       this.scrolledDown = false;
       this.timelineLoading = true;
       this.wikidataArtist = null;
@@ -48,6 +50,7 @@ export const useArtist = defineStore("artist", {
       this.topTracks = { tracks: [] };
       this.albums = [];
       this.albumsLive = [];
+      this.albumsCompilation = [];
       this.eps = [];
       this.singles = [];
       this.relatedArtists = { artists: [] };
@@ -82,6 +85,10 @@ export const useArtist = defineStore("artist", {
         ]);
 
         if (data.next) await this.getAlbums(data.next);
+
+        // Spotify mis-files EPs and live records under the "album" group.
+        // Reclassify with external data (no-op until release types arrive).
+        this.reclassifyReleases();
       } catch {
         // silent fail
       }
@@ -104,6 +111,29 @@ export const useArtist = defineStore("artist", {
       }
     },
 
+    async getCompilations(url: string) {
+      try {
+        const cleanedUrl = cleanUrl(url);
+        const { data }
+          = await instance().get<Paging<AlbumSimplified>>(cleanedUrl);
+
+        const frenchMarketAlbums = data.items.filter((album) =>
+          album.available_markets.includes("FR"),
+        );
+
+        this.albumsCompilation = removeDuplicatesAlbums([
+          ...this.albumsCompilation,
+          ...frenchMarketAlbums,
+        ]);
+
+        if (data.next) await this.getCompilations(data.next);
+
+        this.reclassifyReleases();
+      } catch {
+        // silent fail
+      }
+    },
+
     async getDiscogsArtist(discogsId: string) {
       try {
         const artist = await getDiscogsArtist(discogsId);
@@ -122,7 +152,14 @@ export const useArtist = defineStore("artist", {
         const releasesData = await getDiscogsArtistReleases(discogsId);
 
         if (releasesData) {
-          this.discogsReleases = processDiscogsReleases(releasesData.releases);
+          // MusicBrainz is the primary source and must win, so Discogs only fills
+          // in keys MusicBrainz didn't provide (existing entries take precedence).
+          this.releaseTypes = new Map([
+            ...processDiscogsReleases(releasesData.releases),
+            ...this.releaseTypes,
+          ]);
+          // Data may land after albums/EPs were classified — re-run.
+          this.reclassifyReleases();
         }
       } catch {
         // silent fail
@@ -166,6 +203,9 @@ export const useArtist = defineStore("artist", {
         this.musicbrainzArtist = { ...artist, ...artistFull };
         this.bandMembers = extractBandMembers(artistFull);
 
+        // Primary source for Live/Compilation/EP classification.
+        this.getReleaseGroups(artist.id);
+
         const { discogsId, wikidataId } = extractExternalIds(artistFull);
 
         // Update discogs fields: set or clear and fetch when present
@@ -204,6 +244,22 @@ export const useArtist = defineStore("artist", {
       }
     },
 
+    async getReleaseGroups(musicbrainzId: string) {
+      try {
+        const groups = await getMusicBrainzReleaseGroups(musicbrainzId);
+        if (!groups.length) return;
+
+        // MusicBrainz wins over any Discogs data already present.
+        this.releaseTypes = new Map([
+          ...this.releaseTypes,
+          ...buildReleaseTypeMap(groups),
+        ]);
+        this.reclassifyReleases();
+      } catch {
+        // silent fail
+      }
+    },
+
     async getSingles(artistId: string) {
       try {
         const { data } = await instance().get<Paging<AlbumSimplified>>(
@@ -216,11 +272,11 @@ export const useArtist = defineStore("artist", {
 
         data.items.forEach((item) => {
           const normalizedName = normalizeString(item.name);
-          const discogsType = this.discogsReleases.get(normalizedName);
+          const externalType = this.releaseTypes.get(normalizedName);
 
-          if (discogsType === "EP") {
+          if (externalType === "EP") {
             onlyEps.push(item);
-          } else if (discogsType === "Album") {
+          } else if (externalType === "Album") {
             albumsToMove.push(item);
           } else if (isEP(item)) {
             onlyEps.push(item);
@@ -237,6 +293,8 @@ export const useArtist = defineStore("artist", {
             ...albumsToMove,
           ]);
         }
+
+        this.reclassifyReleases();
       } catch {
         // silent fail
       }
@@ -296,6 +354,66 @@ export const useArtist = defineStore("artist", {
       }
     },
 
+    /**
+     * Reconcile Spotify's grouping with external data (MusicBrainz release-groups
+     * first, Discogs as fallback — see {@link releaseTypes}).
+     *
+     * Spotify is unreliable: it routinely files real EPs and live records under
+     * the plain "album" group (where heuristics can't catch them since
+     * `album_type` is "album") and, more rarely, the reverse. When the external
+     * sources have an explicit type for a release we trust it and move the
+     * release to the right bucket: EP, Live, Compilation or Album.
+     *
+     * Lives already detected by the name heuristic (`useCheckLiveAlbum`) are
+     * never demoted back to albums — external data only adds coverage, it does
+     * not override a positive name match.
+     *
+     * Idempotent and a no-op until `releaseTypes` is populated, so it is safe to
+     * call from every loader regardless of which finishes first (the data is
+     * fetched concurrently and order is not guaranteed).
+     */
+    reclassifyReleases(): void {
+      if (this.releaseTypes.size === 0) return;
+
+      const externalType = (album: AlbumSimplified): string | undefined =>
+        this.releaseTypes.get(normalizeString(album.name));
+
+      const keptAlbums: AlbumSimplified[] = [];
+      const promotedToEps: AlbumSimplified[] = [];
+      const promotedToLive: AlbumSimplified[] = [];
+      const promotedToCompilation: AlbumSimplified[] = [];
+      this.albums.forEach((album) => {
+        switch (externalType(album)) {
+          case "Compilation":
+            promotedToCompilation.push(album);
+            break;
+          case "EP":
+            promotedToEps.push(album);
+            break;
+          case "Live":
+            promotedToLive.push(album);
+            break;
+          default:
+            keptAlbums.push(album);
+        }
+      });
+
+      const keptEps: AlbumSimplified[] = [];
+      const promotedToAlbums: AlbumSimplified[] = [];
+      this.eps.forEach((ep) => {
+        if (externalType(ep) === "Album") promotedToAlbums.push(ep);
+        else keptEps.push(ep);
+      });
+
+      this.albums = removeDuplicatesAlbums([...keptAlbums, ...promotedToAlbums]);
+      this.eps = removeDuplicatesAlbums([...keptEps, ...promotedToEps]);
+      this.albumsLive = removeDuplicatesAlbums([...this.albumsLive, ...promotedToLive]);
+      this.albumsCompilation = removeDuplicatesAlbums([
+        ...this.albumsCompilation,
+        ...promotedToCompilation,
+      ]);
+    },
+
     async switchFollow(artistId: string) {
       // Optimistic update, reverted if the API call fails
       const previousStatus = this.followStatus;
@@ -324,17 +442,18 @@ export const useArtist = defineStore("artist", {
   state: (): ArtistPage => ({
     activeTab: "discography",
     albums: [],
+    albumsCompilation: [],
     albumsLive: [],
     artist: defaultArtist,
     bandMembers: [],
     discogsArtist: null,
     discogsId: null,
-    discogsReleases: new Map(),
     eps: [],
     followStatus: false,
     headerHeight: 0,
     musicbrainzArtist: null,
     relatedArtists: { artists: [] },
+    releaseTypes: new Map(),
     scrolledDown: false,
     singles: [],
     timelineLoading: false,


### PR DESCRIPTION
Retrieve and display compilation albums for artists using Spotify's compilation group and external metadata from MusicBrainz and Discogs to improve classification accuracy.