### PR TITLE
feat(updater): add support for app restarts after update

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "@tauri-apps/api": "^2.11.1",
         "@tauri-apps/plugin-deep-link": "^2.4.9",
         "@tauri-apps/plugin-opener": "^2.5.4",
+        "@tauri-apps/plugin-process": "^2.3.1",
         "@tauri-apps/plugin-updater": "^2.10.1",
         "@vueuse/motion": "^3.0.3",
         "crypto-js": "^4.2.0",
@@ -286,6 +287,8 @@
     "@tauri-apps/plugin-deep-link": ["@tauri-apps/plugin-deep-link@2.4.9", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" } }, "sha512-u0SKOUHnJ1wqeqXsDFq2+kASCBj9xxbG0g9XZWPy9SOmU4wXtp6b/wiYpm6oH6/5fBTQsLqnLhIvqLBRpgHJlA=="],
 
     "@tauri-apps/plugin-opener": ["@tauri-apps/plugin-opener@2.5.4", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" } }, "sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ=="],
+
+    "@tauri-apps/plugin-process": ["@tauri-apps/plugin-process@2.3.1", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA=="],
 
     "@tauri-apps/plugin-updater": ["@tauri-apps/plugin-updater@2.10.1", "", { "dependencies": { "@tauri-apps/api": "^2.10.1" } }, "sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA=="],
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@tauri-apps/api": "^2.11.1",
     "@tauri-apps/plugin-deep-link": "^2.4.9",
     "@tauri-apps/plugin-opener": "^2.5.4",
+    "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-updater": "^2.10.1",
     "@vueuse/motion": "^3.0.3",
     "crypto-js": "^4.2.0",

--- a/scripts/package-release.ts
+++ b/scripts/package-release.ts
@@ -54,8 +54,18 @@ if (existsSync(nsisDir)) {
       src: join(nsisDir, nsisExes[0].file),
     });
   }
+}
 
-  const nsisZips = nsisFiles
+// Updater artifacts (.nsis.zip + .sig) — Tauri writes these to a separate
+// "nsis-updater" folder, not "nsis", when bundle.createUpdaterArtifacts is enabled.
+const nsisUpdaterDir = join(bundleDir, "nsis-updater");
+if (existsSync(nsisUpdaterDir)) {
+  const updaterFiles = readdirSync(nsisUpdaterDir).map((f) => ({
+    file: f,
+    mtime: statSync(join(nsisUpdaterDir, f)).mtimeMs,
+  }));
+
+  const nsisZips = updaterFiles
     .filter((f) => f.file.endsWith(".nsis.zip") && !f.file.endsWith(".sig"))
     .sort((a, b) => b.mtime - a.mtime);
 
@@ -63,10 +73,10 @@ if (existsSync(nsisDir)) {
     nsisZipName = `beardify_${version}_x64-setup.nsis.zip`;
     artifacts.push({
       dest: join(outDir, nsisZipName),
-      src: join(nsisDir, nsisZips[0].file),
+      src: join(nsisUpdaterDir, nsisZips[0].file),
     });
 
-    const sigFile = join(nsisDir, `${nsisZips[0].file}.sig`);
+    const sigFile = join(nsisUpdaterDir, `${nsisZips[0].file}.sig`);
     if (existsSync(sigFile)) {
       const sigDest = `${nsisZipName}.sig`;
       artifacts.push({

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,6 +17,7 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = [] }
 tauri-plugin-deep-link = "2"
 tauri-plugin-opener = "2"
+tauri-plugin-process = "2"
 tauri-plugin-single-instance = "2"
 tauri-plugin-updater = "2"
 serde = { version = "1", features = ["derive"] }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -15,6 +15,7 @@
     "opener:allow-open-url",
     "updater:default",
     "updater:allow-check",
-    "updater:allow-download-and-install"
+    "updater:allow-download-and-install",
+    "process:allow-restart"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -45,6 +45,7 @@ pub fn run() {
         }))
         .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_process::init())
         .invoke_handler(tauri::generate_handler![set_play_state, open_spotify_auth])
         .setup(|app| {
             // Register beardify:// in the OS registry so the browser can open deep links.

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -16,6 +16,7 @@
   },
   "bundle": {
     "active": true,
+    "createUpdaterArtifacts": true,
     "targets": [
       "msi",
       "nsis"

--- a/src/components/ui/UpdateToast.vue
+++ b/src/components/ui/UpdateToast.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useUpdater } from "@/composables/useUpdater";
 
-const { dismissed, downloadAndInstall, downloadProgress, status, updateVersion } = useUpdater();
+const { dismissed, downloadAndInstall, downloadProgress, restart, status, updateVersion } = useUpdater();
 </script>
 
 <template>
@@ -25,6 +25,10 @@ const { dismissed, downloadAndInstall, downloadProgress, status, updateVersion }
 
         <button v-if="status === 'available'" class="toast-action" @click="downloadAndInstall">
           Install
+        </button>
+
+        <button v-if="status === 'ready'" class="toast-action" @click="restart">
+          Restart
         </button>
 
         <button v-if="status === 'available'" class="toast-dismiss" aria-label="Dismiss" @click="dismissed = true">

--- a/src/composables/useUpdater.ts
+++ b/src/composables/useUpdater.ts
@@ -8,6 +8,7 @@ interface UpdaterState {
   downloadAndInstall: () => Promise<void>;
   downloadProgress: Ref<number>;
   errorMessage: Ref<null | string>;
+  restart: () => Promise<void>;
   status: Ref<UpdateStatus>;
   updateVersion: Ref<null | string>;
 }
@@ -29,6 +30,7 @@ export function useUpdater(): UpdaterState {
     downloadAndInstall,
     downloadProgress,
     errorMessage,
+    restart,
     status,
     updateVersion,
   };
@@ -75,6 +77,11 @@ async function downloadAndInstall(): Promise<void> {
     errorMessage.value = toMessage(e);
     status.value = "error";
   }
+}
+
+async function restart(): Promise<void> {
+  const { relaunch } = await import("@tauri-apps/plugin-process");
+  await relaunch();
 }
 
 function toMessage(e: unknown): string {


### PR DESCRIPTION
Configure the Tauri process plugin to enable automatic restarts and update the release script to correctly locate and package updater artifacts.