### PR TITLE
refactor(router): use canonical origin for absolute URLs

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <template v-if="useRoute().meta.chromeless">
+  <template v-if="route.meta.chromeless">
     <router-view />
   </template>
   <template v-else>
@@ -8,8 +8,8 @@
       <Sidebar />
       <div class="main-content">
         <MobileHeader />
-        <router-view v-slot="{ Component, route }">
-          <component :is="Component" :key="route.fullPath" />
+        <router-view v-slot="{ Component, route: currentRoute }">
+          <component :is="Component" :key="currentRoute.fullPath" />
         </router-view>
       </div>
     </div>
@@ -48,6 +48,7 @@ useKeyboardEvents();
 const authStore = useAuth();
 const { checkForUpdate } = useUpdater();
 const dialog = useDialog();
+const route = useRoute();
 
 onMounted(() => {
   if (isTauri()) {
@@ -77,7 +78,7 @@ if (!navigator.userAgent.includes("Macintosh")) {
 
 // Chromeless routes render without a Spotify session (see the branch above) —
 // polling for a device list or refreshing a token there would only waste requests.
-const hasNoSession = (): boolean => !!useRoute().meta.chromeless;
+const hasNoSession = (): boolean => !!route.meta.chromeless;
 
 // Keep device list fresh every 5 minutes
 const deviceRefreshInterval = setInterval(async () => {

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory, LocationQueryValue, RouteLocation, RouteRecordRaw } from "vue-router";
 
+import { isTauri } from "@/helpers/platform";
 import AlbumPage from "@/views/album/AlbumPage.vue";
 import ArtistPage from "@/views/artist/ArtistPage.vue";
 import AuthPage from "@/views/auth/AuthPage.vue";
@@ -38,11 +39,17 @@ export enum RouteName {
   User = "/user/",
 }
 
+// The Tauri desktop app's webview runs on an internal `tauri://`/`http://tauri.localhost`
+// origin, which is meaningless to whoever opens a shared link — fall back to the real
+// web domain there instead of `window.location.origin`.
+const PROD_APP_URL = "https://beardify.netlify.app";
+
 /**
  * Builds an absolute, shareable URL for a route that takes an id (e.g. Collection, Share).
  */
 export function absoluteRouteUrl(routeName: RouteName, id: string): string {
-  return `${window.location.origin}${routeName}${id}`;
+  const origin = isTauri() ? PROD_APP_URL : window.location.origin;
+  return `${origin}${routeName}${id}`;
 }
 
 const routes: Array<RouteRecordRaw> = [


### PR DESCRIPTION
Replace `window.location.origin` with a canonical domain when running in Tauri to ensure shared links use the public web address instead of the internal Tauri origin. Also optimize route usage in App.vue.