### PR TITLE
feat(collection): move #Collection tag to description, add Top ranking

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ bun run lint          # TypeScript + ESLint + Stylelint
 bun run fix           # auto-fix lint issues
 bun run build         # production web build (runs lint first)
 bun run tauri:build   # production desktop build
+bunx netlify functions:serve # serve Netlify functions locally (testing share)
 ```
 
 ## Releasing a new version

--- a/deno.lock
+++ b/deno.lock
@@ -57,9 +57,9 @@
         "npm:typescript@6.0.3",
         "npm:vite-plugin-static-copy@^4.1.1",
         "npm:vite@^8.1.0",
+        "npm:vue-draggable-plus@~0.6.1",
         "npm:vue-eslint-parser@^10.4.1",
         "npm:vue-router@^5.1.0",
-        "npm:vue-slicksort@^2.0.5",
         "npm:vue-tsc@^3.3.5",
         "npm:vue@^3.5.38"
       ]

--- a/src/@types/Config.ts
+++ b/src/@types/Config.ts
@@ -5,6 +5,7 @@ export interface Config {
   show: boolean;
   theme: ThemeColor[];
   themeLabel: ThemeLabel;
+  tierListSideLabels: boolean;
 }
 
 export type SchemeLabel = "apple" | "blue" | "crimson" | "default" | "orange";

--- a/src/@types/Dialog.ts
+++ b/src/@types/Dialog.ts
@@ -1,3 +1,4 @@
+import { TopTiers } from "@/helpers/collectionOptions";
 import { AlbumGroup } from "@/helpers/groupAlbumVariants";
 
 import { Track, TrackSimplified } from "./Track";
@@ -32,4 +33,5 @@ export interface UpdatePlaylistValues {
   description: string;
   name: string;
   public: boolean;
+  topTiers: null | TopTiers;
 }

--- a/src/@types/Dialog.ts
+++ b/src/@types/Dialog.ts
@@ -1,4 +1,4 @@
-import { TopTiers } from "@/helpers/collectionOptions";
+import { CollectionRankingMode } from "@/helpers/collectionOptions";
 import { AlbumGroup } from "@/helpers/groupAlbumVariants";
 
 import { Track, TrackSimplified } from "./Track";
@@ -33,5 +33,5 @@ export interface UpdatePlaylistValues {
   description: string;
   name: string;
   public: boolean;
-  topTiers: null | TopTiers;
+  rankingMode: CollectionRankingMode;
 }

--- a/src/assets/scss/mixins.scss
+++ b/src/assets/scss/mixins.scss
@@ -48,6 +48,91 @@
     "wght" var(--font-variation-wght-bold);
 }
 
+// Collapses .metas to zero height by default and pins the card's own box to
+// a fixed square: aspect-ratio + align-self: start prevents grid/flex
+// stretch from growing the whole row to match .visual's revealed height
+// once it pops out (see hover-metas-reveal). Shared by AlbumIndex.vue and
+// SharedAlbumCard.vue — pass the cover element's own class since it differs
+// between them (.cover vs .album-cover).
+@mixin hover-metas-base($cover-selector) {
+  align-self: start;
+  aspect-ratio: 1 / 1;
+
+  .visual {
+    display: flex;
+    flex-direction: column;
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+  }
+
+  #{$cover-selector} {
+    margin-bottom: 0;
+  }
+
+  .metas {
+    margin-top: 0;
+    max-height: 0;
+    opacity: 0;
+    overflow: hidden;
+    transition:
+      margin-top ease 0.2s,
+      max-height ease 0.2s,
+      opacity ease 0.15s;
+  }
+}
+
+// The revealed state: .visual pops a background card outside the item's own
+// box (no `bottom`, so it grows downward over whatever's below instead of
+// pushing it) and .metas becomes visible. Include inside whatever trigger
+// selector applies (:hover, .actions-open, ...).
+@mixin hover-metas-reveal {
+  .visual {
+    background-color: var(--bg-color-light);
+    border-radius: 0.6rem;
+    box-shadow: 0 0.5rem 1.5rem rgb(0 0 0 / 40%);
+    padding: 0.6rem;
+    z-index: 5;
+  }
+
+  .metas {
+    margin-top: 0.6rem;
+    max-height: 10rem;
+    opacity: 1;
+  }
+}
+
+// Overlays the info on top of the cover (top edge) instead of growing the
+// card past its own box. Used where downward growth would get clipped by an
+// ancestor's overflow (e.g. a horizontally scrolling row — overflow-x: auto
+// forces overflow-y: auto too, so anything popping outside gets clipped
+// regardless of direction; staying within the card's own square avoids it).
+@mixin hover-metas-above-base {
+  .metas {
+    background: linear-gradient(rgb(0 0 0 / 85%) 40%, rgb(0 0 0 / 0%));
+    border-radius: 0.6rem 0.6rem 0 0;
+    color: #fff;
+    left: 0;
+    margin: 0;
+    padding: 0.6rem;
+    pointer-events: none;
+    position: absolute;
+    right: 0;
+    top: 0;
+    transition: opacity ease 0.15s;
+    z-index: 3;
+  }
+}
+
+@mixin hover-metas-above-reveal {
+  .metas {
+    margin: 0;
+    max-height: none;
+    opacity: 1;
+  }
+}
+
 @keyframes pop-content {
   from {
     opacity: 0;

--- a/src/assets/scss/mixins.scss
+++ b/src/assets/scss/mixins.scss
@@ -65,6 +65,7 @@
     position: absolute;
     right: 0;
     top: 0;
+    transition: padding 0.15s ease;
   }
 
   #{$cover-selector} {
@@ -130,6 +131,10 @@
     margin: 0;
     max-height: none;
     opacity: 1;
+  }
+
+  .visual {
+    padding: 0;
   }
 }
 

--- a/src/components/album/AlbumIndex.vue
+++ b/src/components/album/AlbumIndex.vue
@@ -4,7 +4,6 @@
       <i class="icon-volume-2" />
     </div>
     <div :class="{ 'is-playing': isPlaying }" class="cover">
-      <div v-if="rank" class="rank-badge">{{ rank }}</div>
       <Cover :images="album.images" :size="coverSize ? coverSize : 'medium'" class="img" @click="handleCoverClick" />
       <ButtonIndex no-default-class class="play" type="button" @click.stop="handlePlayAlbum(album.uri)">
         <i class="icon-play" />
@@ -38,15 +37,18 @@
         </div>
       </div>
     </div>
-    <div v-if="!withoutMetas">
-      <div class="name">
-        {{ album.name }}
-      </div>
-      <div v-if="withArtists" class="artists">
-        <ArtistList :artist-list="album.artists" feat />
-      </div>
-      <div v-if="album.release_date && !withoutReleaseDate" class="date">
-        {{ album.release_date.split("-").shift() }}
+    <div v-if="!withoutMetas" class="metas">
+      <div v-if="rank" class="rank-number">{{ rank }}</div>
+      <div class="infos">
+        <div class="name">
+          {{ album.name }}
+        </div>
+        <div v-if="withArtists" class="artists">
+          <ArtistList :artist-list="album.artists" feat />
+        </div>
+        <div v-if="album.release_date && !withoutReleaseDate" class="date">
+          {{ album.release_date.split("-").shift() }}
+        </div>
       </div>
     </div>
   </div>
@@ -313,22 +315,22 @@ async function handlePlayAlbum(albumUri: string): Promise<void> {
   }
 }
 
-.rank-badge {
-  $size: 2.2rem;
-
+.metas {
   align-items: center;
-  background: var(--bg-color-darker);
-  border-radius: 100%;
-  box-shadow: 0 0.1rem 0.4rem rgb(0 0 0 / 40%);
   display: flex;
-  font-size: var(--font-size-sm);
-  height: $size;
-  justify-content: center;
-  left: 0.5rem;
-  position: absolute;
-  top: 0.5rem;
-  width: $size;
-  z-index: 1;
+  gap: 0.8rem;
+}
+
+.infos {
+  flex: 1;
+  min-width: 0;
+}
+
+.rank-number {
+  color: var(--font-color-light);
+  flex-shrink: 0;
+  font-size: 2.4rem;
+  line-height: 1;
 
   @include font-bold;
 }

--- a/src/components/album/AlbumIndex.vue
+++ b/src/components/album/AlbumIndex.vue
@@ -336,108 +336,31 @@ async function handlePlayAlbum(albumUri: string): Promise<void> {
   gap: 0.8rem;
 }
 
-// aspect-ratio pins .album's own box to the cover's square size regardless of
-// .visual's revealed content. align-self: start is required too — the grid
-// and flex containers here default to `stretch`, which otherwise grows the
-// item (and the whole row, flickering the layout) to match .visual once it
-// pops out on hover. .visual is always absolutely positioned inside that
-// fixed box (no `bottom`, so it's free to extend past it downward on reveal,
-// over any content below, instead of pushing it).
 .album.hover-metas {
-  align-self: start;
-  aspect-ratio: 1 / 1;
-
-  .visual {
-    display: flex;
-    flex-direction: column;
-    left: 0;
-    position: absolute;
-    right: 0;
-    top: 0;
-  }
-
-  .cover {
-    margin-bottom: 0;
-  }
-
-  .metas {
-    margin-top: 0;
-    max-height: 0;
-    opacity: 0;
-    overflow: hidden;
-    transition:
-      margin-top ease 0.2s,
-      max-height ease 0.2s,
-      opacity ease 0.15s;
-  }
+  @include hover-metas-base(".cover");
 
   // .dragging suppresses the reveal (any card the pointer passes over while
   // dragging another one would otherwise pop its info open mid-drag).
-  &.actions-open:not(.dragging) .visual {
-    background-color: var(--bg-color-light);
-    border-radius: 0.6rem;
-    box-shadow: 0 0.5rem 1.5rem rgb(0 0 0 / 40%);
-    padding: 0.6rem;
-    z-index: 5;
-  }
-
-  &.actions-open:not(.dragging) .metas {
-    margin-top: 0.6rem;
-    max-height: 10rem;
-    opacity: 1;
+  &.actions-open:not(.dragging) {
+    @include hover-metas-reveal;
   }
 }
 
-// Overlays the info on top of the cover (top edge) instead of growing the
-// card past its own box. The regular .hover-metas grow-outside mechanic
-// needs its ancestor's overflow to stay visible, which the horizontally
-// scrolling Unsorted row can't do — overflow-x: auto forces overflow-y:
-// auto too (an element can't scroll one axis and stay clip-free on the
-// other), so anything popping outside .unsorted-scroll's box gets clipped
-// regardless of direction. Staying within the card's own square avoids that
-// entirely.
 .album.hover-metas.metas-above {
-  .metas {
-    background: linear-gradient(rgb(0 0 0 / 85%) 40%, rgb(0 0 0 / 0%));
-    border-radius: 0.6rem 0.6rem 0 0;
-    color: #fff;
-    left: 0;
-    margin: 0;
-    padding: 0.6rem;
-    pointer-events: none;
-    position: absolute;
-    right: 0;
-    top: 0;
-    transition: opacity ease 0.15s;
-    z-index: 3;
-  }
+  @include hover-metas-above-base;
 
-  &.actions-open:not(.dragging) .metas {
-    margin: 0;
-    max-height: none;
-    opacity: 1;
+  &.actions-open:not(.dragging) {
+    @include hover-metas-above-reveal;
   }
 }
 
 @media (hover: hover) {
-  .album.hover-metas:hover:not(.dragging) .visual {
-    background-color: var(--bg-color-light);
-    border-radius: 0.6rem;
-    box-shadow: 0 0.5rem 1.5rem rgb(0 0 0 / 40%);
-    padding: 0.6rem;
-    z-index: 5;
+  .album.hover-metas:hover:not(.dragging) {
+    @include hover-metas-reveal;
   }
 
-  .album.hover-metas:hover:not(.dragging) .metas {
-    margin-top: 0.6rem;
-    max-height: 10rem;
-    opacity: 1;
-  }
-
-  .album.hover-metas.metas-above:hover:not(.dragging) .metas {
-    margin: 0;
-    max-height: none;
-    opacity: 1;
+  .album.hover-metas.metas-above:hover:not(.dragging) {
+    @include hover-metas-above-reveal;
   }
 }
 

--- a/src/components/album/AlbumIndex.vue
+++ b/src/components/album/AlbumIndex.vue
@@ -1,53 +1,65 @@
 <template>
-  <div ref="albumRef" :class="{ 'exact-search': exactSearch, 'actions-open': actionsOpen }" class="album">
+  <div
+    ref="albumRef"
+    :class="{
+      'exact-search': exactSearch,
+      'actions-open': actionsOpen,
+      dragging,
+      'hover-metas': hoverMetas,
+      'metas-above': metasAbove,
+    }"
+    class="album"
+  >
     <div v-if="isPlaying" class="current">
       <i class="icon-volume-2" />
     </div>
-    <div :class="{ 'is-playing': isPlaying }" class="cover">
-      <Cover :images="album.images" :size="coverSize ? coverSize : 'medium'" class="img" @click="handleCoverClick" />
-      <ButtonIndex no-default-class class="play" type="button" @click.stop="handlePlayAlbum(album.uri)">
-        <i class="icon-play" />
-      </ButtonIndex>
-      <ButtonIndex
-        v-if="canSave"
-        no-default-class
-        class="button-action add"
-        type="button"
-        @click.stop="dialogStore.open({ type: 'addalbum', albumId: album.id })"
-      >
-        <i class="icon-plus" />
-      </ButtonIndex>
-      <ButtonIndex
-        v-if="canDelete"
-        no-default-class
-        class="button-action delete"
-        type="button"
-        @click.stop="deleteAlbum(album.id)"
-      >
-        <i class="icon-trash-2" />
-      </ButtonIndex>
-      <div
-        v-if="variantCount && variantCount > 0"
-        class="album-group-stack-indicator"
-        @click.stop="variantClick && variantClick()"
-      >
-        <div class="album-group-stack-layer album-group-stack-layer-1" />
-        <div class="album-group-stack-layer album-group-stack-layer-2">
-          {{ variantCount }}
+    <div class="visual">
+      <div :class="{ 'is-playing': isPlaying }" class="cover">
+        <Cover :images="album.images" :size="coverSize ? coverSize : 'medium'" class="img" @click="handleCoverClick" />
+        <ButtonIndex no-default-class class="play" type="button" @click.stop="handlePlayAlbum(album.uri)">
+          <i class="icon-play" />
+        </ButtonIndex>
+        <ButtonIndex
+          v-if="canSave"
+          no-default-class
+          class="button-action add"
+          type="button"
+          @click.stop="dialogStore.open({ type: 'addalbum', albumId: album.id })"
+        >
+          <i class="icon-plus" />
+        </ButtonIndex>
+        <ButtonIndex
+          v-if="canDelete"
+          no-default-class
+          class="button-action delete"
+          type="button"
+          @click.stop="deleteAlbum(album.id)"
+        >
+          <i class="icon-trash-2" />
+        </ButtonIndex>
+        <div
+          v-if="variantCount && variantCount > 0"
+          class="album-group-stack-indicator"
+          @click.stop="variantClick && variantClick()"
+        >
+          <div class="album-group-stack-layer album-group-stack-layer-1" />
+          <div class="album-group-stack-layer album-group-stack-layer-2">
+            {{ variantCount }}
+          </div>
         </div>
       </div>
-    </div>
-    <div v-if="!withoutMetas" class="metas">
-      <div v-if="rank" class="rank-number">{{ rank }}</div>
-      <div class="infos">
-        <div class="name">
-          {{ album.name }}
-        </div>
-        <div v-if="withArtists" class="artists">
-          <ArtistList :artist-list="album.artists" feat />
-        </div>
-        <div v-if="album.release_date && !withoutReleaseDate" class="date">
-          {{ album.release_date.split("-").shift() }}
+      <div v-if="!withoutMetas" class="metas">
+        <div v-if="rank" class="rank-number">{{ rank }}</div>
+        <div class="infos">
+          <div class="name">
+            {{ album.name }}
+          </div>
+          <div v-if="withArtists" class="artists">
+            <ArtistList :artist-list="album.artists" feat />
+          </div>
+          <div v-if="album.release_date && !withoutReleaseDate" class="date">
+            {{ album.release_date.split("-").shift() }}
+          </div>
         </div>
       </div>
     </div>
@@ -81,7 +93,10 @@ const props = defineProps<{
   canDelete?: boolean;
   canSave?: boolean;
   coverSize?: ImageSize | undefined;
+  dragging?: boolean;
   exactSearch?: boolean;
+  hoverMetas?: boolean;
+  metasAbove?: boolean;
   rank?: number;
   variantClick?: (() => void) | undefined;
   variantCount?: number;
@@ -319,6 +334,111 @@ async function handlePlayAlbum(albumUri: string): Promise<void> {
   align-items: center;
   display: flex;
   gap: 0.8rem;
+}
+
+// aspect-ratio pins .album's own box to the cover's square size regardless of
+// .visual's revealed content. align-self: start is required too — the grid
+// and flex containers here default to `stretch`, which otherwise grows the
+// item (and the whole row, flickering the layout) to match .visual once it
+// pops out on hover. .visual is always absolutely positioned inside that
+// fixed box (no `bottom`, so it's free to extend past it downward on reveal,
+// over any content below, instead of pushing it).
+.album.hover-metas {
+  align-self: start;
+  aspect-ratio: 1 / 1;
+
+  .visual {
+    display: flex;
+    flex-direction: column;
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+  }
+
+  .cover {
+    margin-bottom: 0;
+  }
+
+  .metas {
+    margin-top: 0;
+    max-height: 0;
+    opacity: 0;
+    overflow: hidden;
+    transition:
+      margin-top ease 0.2s,
+      max-height ease 0.2s,
+      opacity ease 0.15s;
+  }
+
+  // .dragging suppresses the reveal (any card the pointer passes over while
+  // dragging another one would otherwise pop its info open mid-drag).
+  &.actions-open:not(.dragging) .visual {
+    background-color: var(--bg-color-light);
+    border-radius: 0.6rem;
+    box-shadow: 0 0.5rem 1.5rem rgb(0 0 0 / 40%);
+    padding: 0.6rem;
+    z-index: 5;
+  }
+
+  &.actions-open:not(.dragging) .metas {
+    margin-top: 0.6rem;
+    max-height: 10rem;
+    opacity: 1;
+  }
+}
+
+// Overlays the info on top of the cover (top edge) instead of growing the
+// card past its own box. The regular .hover-metas grow-outside mechanic
+// needs its ancestor's overflow to stay visible, which the horizontally
+// scrolling Unsorted row can't do — overflow-x: auto forces overflow-y:
+// auto too (an element can't scroll one axis and stay clip-free on the
+// other), so anything popping outside .unsorted-scroll's box gets clipped
+// regardless of direction. Staying within the card's own square avoids that
+// entirely.
+.album.hover-metas.metas-above {
+  .metas {
+    background: linear-gradient(rgb(0 0 0 / 85%) 40%, rgb(0 0 0 / 0%));
+    border-radius: 0.6rem 0.6rem 0 0;
+    color: #fff;
+    left: 0;
+    margin: 0;
+    padding: 0.6rem;
+    pointer-events: none;
+    position: absolute;
+    right: 0;
+    top: 0;
+    transition: opacity ease 0.15s;
+    z-index: 3;
+  }
+
+  &.actions-open:not(.dragging) .metas {
+    margin: 0;
+    max-height: none;
+    opacity: 1;
+  }
+}
+
+@media (hover: hover) {
+  .album.hover-metas:hover:not(.dragging) .visual {
+    background-color: var(--bg-color-light);
+    border-radius: 0.6rem;
+    box-shadow: 0 0.5rem 1.5rem rgb(0 0 0 / 40%);
+    padding: 0.6rem;
+    z-index: 5;
+  }
+
+  .album.hover-metas:hover:not(.dragging) .metas {
+    margin-top: 0.6rem;
+    max-height: 10rem;
+    opacity: 1;
+  }
+
+  .album.hover-metas.metas-above:hover:not(.dragging) .metas {
+    margin: 0;
+    max-height: none;
+    opacity: 1;
+  }
 }
 
 .infos {

--- a/src/components/album/AlbumIndex.vue
+++ b/src/components/album/AlbumIndex.vue
@@ -4,6 +4,7 @@
       <i class="icon-volume-2" />
     </div>
     <div :class="{ 'is-playing': isPlaying }" class="cover">
+      <div v-if="rank" class="rank-badge">{{ rank }}</div>
       <Cover :images="album.images" :size="coverSize ? coverSize : 'medium'" class="img" @click="handleCoverClick" />
       <ButtonIndex no-default-class class="play" type="button" @click.stop="handlePlayAlbum(album.uri)">
         <i class="icon-play" />
@@ -79,6 +80,7 @@ const props = defineProps<{
   canSave?: boolean;
   coverSize?: ImageSize | undefined;
   exactSearch?: boolean;
+  rank?: number;
   variantClick?: (() => void) | undefined;
   variantCount?: number;
   withArtists?: boolean;
@@ -309,6 +311,26 @@ async function handlePlayAlbum(albumUri: string): Promise<void> {
     bottom: 1rem;
     right: 1rem;
   }
+}
+
+.rank-badge {
+  $size: 2.2rem;
+
+  align-items: center;
+  background: var(--bg-color-darker);
+  border-radius: 100%;
+  box-shadow: 0 0.1rem 0.4rem rgb(0 0 0 / 40%);
+  display: flex;
+  font-size: var(--font-size-sm);
+  height: $size;
+  justify-content: center;
+  left: 0.5rem;
+  position: absolute;
+  top: 0.5rem;
+  width: $size;
+  z-index: 1;
+
+  @include font-bold;
 }
 
 .current {

--- a/src/components/album/SharedAlbumCard.vue
+++ b/src/components/album/SharedAlbumCard.vue
@@ -51,53 +51,13 @@ defineProps<{
   gap: 0.8rem;
 }
 
-// aspect-ratio pins .album's own box to the cover's square size regardless of
-// .visual's revealed content. align-self: start is required too — the grid
-// and flex containers here default to `stretch`, which otherwise grows the
-// item (and the whole row, flickering the layout) to match .visual once it
-// pops out on hover. .visual is always absolutely positioned inside that
-// fixed box (no `bottom`, so it's free to extend past it downward on reveal,
-// over any content below, instead of pushing it).
 .album.hover-metas {
-  align-self: start;
-  aspect-ratio: 1 / 1;
-
-  .visual {
-    left: 0;
-    position: absolute;
-    right: 0;
-    top: 0;
-  }
-
-  .album-cover {
-    margin-bottom: 0;
-  }
-
-  .metas {
-    margin-top: 0;
-    max-height: 0;
-    opacity: 0;
-    overflow: hidden;
-    transition:
-      margin-top ease 0.2s,
-      max-height ease 0.2s,
-      opacity ease 0.15s;
-  }
+  @include hover-metas-base(".album-cover");
 }
 
 @media (hover: hover) {
-  .album.hover-metas:hover .visual {
-    background-color: var(--bg-color-light);
-    border-radius: 0.6rem;
-    box-shadow: 0 0.5rem 1.5rem rgb(0 0 0 / 40%);
-    padding: 0.6rem;
-    z-index: 5;
-  }
-
-  .album.hover-metas:hover .metas {
-    margin-top: 0.6rem;
-    max-height: 10rem;
-    opacity: 1;
+  .album.hover-metas:hover {
+    @include hover-metas-reveal;
   }
 }
 

--- a/src/components/album/SharedAlbumCard.vue
+++ b/src/components/album/SharedAlbumCard.vue
@@ -1,11 +1,19 @@
 <template>
-  <a class="album" :href="album.external_urls.spotify" rel="noopener" target="_blank">
-    <Cover :images="album.images" class="album-cover" size="medium" />
-    <div class="metas">
-      <div v-if="rank" class="rank-number">{{ rank }}</div>
-      <div class="infos">
-        <div class="name">{{ album.name }}</div>
-        <div class="artists">{{ album.artists.map((a) => a.name).join(", ") }}</div>
+  <a
+    class="album"
+    :class="{ 'hover-metas': hoverMetas }"
+    :href="album.external_urls.spotify"
+    rel="noopener"
+    target="_blank"
+  >
+    <div class="visual">
+      <Cover :images="album.images" class="album-cover" size="medium" />
+      <div class="metas">
+        <div v-if="rank" class="rank-number">{{ rank }}</div>
+        <div class="infos">
+          <div class="name">{{ album.name }}</div>
+          <div class="artists">{{ album.artists.map((a) => a.name).join(", ") }}</div>
+        </div>
       </div>
     </div>
   </a>
@@ -17,6 +25,7 @@ import Cover from "@/components/ui/AlbumCover.vue";
 
 defineProps<{
   album: AlbumSimplified;
+  hoverMetas?: boolean;
   rank?: number;
 }>();
 </script>
@@ -26,6 +35,7 @@ defineProps<{
 
 .album {
   color: inherit;
+  position: relative;
   text-decoration: none;
 }
 
@@ -39,6 +49,56 @@ defineProps<{
   align-items: center;
   display: flex;
   gap: 0.8rem;
+}
+
+// aspect-ratio pins .album's own box to the cover's square size regardless of
+// .visual's revealed content. align-self: start is required too — the grid
+// and flex containers here default to `stretch`, which otherwise grows the
+// item (and the whole row, flickering the layout) to match .visual once it
+// pops out on hover. .visual is always absolutely positioned inside that
+// fixed box (no `bottom`, so it's free to extend past it downward on reveal,
+// over any content below, instead of pushing it).
+.album.hover-metas {
+  align-self: start;
+  aspect-ratio: 1 / 1;
+
+  .visual {
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+  }
+
+  .album-cover {
+    margin-bottom: 0;
+  }
+
+  .metas {
+    margin-top: 0;
+    max-height: 0;
+    opacity: 0;
+    overflow: hidden;
+    transition:
+      margin-top ease 0.2s,
+      max-height ease 0.2s,
+      opacity ease 0.15s;
+  }
+}
+
+@media (hover: hover) {
+  .album.hover-metas:hover .visual {
+    background-color: var(--bg-color-light);
+    border-radius: 0.6rem;
+    box-shadow: 0 0.5rem 1.5rem rgb(0 0 0 / 40%);
+    padding: 0.6rem;
+    z-index: 5;
+  }
+
+  .album.hover-metas:hover .metas {
+    margin-top: 0.6rem;
+    max-height: 10rem;
+    opacity: 1;
+  }
 }
 
 .infos {

--- a/src/components/album/SharedAlbumCard.vue
+++ b/src/components/album/SharedAlbumCard.vue
@@ -1,0 +1,65 @@
+<template>
+  <a class="album" :href="album.external_urls.spotify" rel="noopener" target="_blank">
+    <Cover :images="album.images" class="album-cover" size="medium" />
+    <div class="metas">
+      <div v-if="rank" class="rank-number">{{ rank }}</div>
+      <div class="infos">
+        <div class="name">{{ album.name }}</div>
+        <div class="artists">{{ album.artists.map((a) => a.name).join(", ") }}</div>
+      </div>
+    </div>
+  </a>
+</template>
+
+<script lang="ts" setup>
+import { AlbumSimplified } from "@/@types/Album";
+import Cover from "@/components/ui/AlbumCover.vue";
+
+defineProps<{
+  album: AlbumSimplified;
+  rank?: number;
+}>();
+</script>
+
+<style lang="scss" scoped>
+@use "@/assets/scss/mixins" as *;
+
+.album {
+  color: inherit;
+  text-decoration: none;
+}
+
+.album-cover {
+  border-radius: 0.4rem;
+  margin-bottom: 0.5rem;
+  width: 100%;
+}
+
+.metas {
+  align-items: center;
+  display: flex;
+  gap: 0.8rem;
+}
+
+.infos {
+  flex: 1;
+  min-width: 0;
+}
+
+.rank-number {
+  color: var(--font-color-light);
+  flex-shrink: 0;
+  font-size: 2.4rem;
+  line-height: 1;
+
+  @include font-bold;
+}
+
+.name {
+  @include font-bold;
+}
+
+.artists {
+  opacity: 0.6;
+}
+</style>

--- a/src/components/config/ConfigIndex.vue
+++ b/src/components/config/ConfigIndex.vue
@@ -35,6 +35,27 @@
       <Colors />
     </div>
 
+    <div class="section">
+      <div class="section-title">Tier list</div>
+      <div class="option">
+        <div class="option-label">Side labels</div>
+        <div class="buttons">
+          <ButtonIndex
+            :variant="!configStore.tierListSideLabels ? 'primary' : 'default'"
+            @click="configStore.toggleTierListSideLabels(false)"
+          >
+            Off
+          </ButtonIndex>
+          <ButtonIndex
+            :variant="configStore.tierListSideLabels ? 'primary' : 'default'"
+            @click="configStore.toggleTierListSideLabels(true)"
+          >
+            On
+          </ButtonIndex>
+        </div>
+      </div>
+    </div>
+
     <div class="version">v{{ appVersion }}</div>
   </div>
 </template>
@@ -81,6 +102,17 @@ onClickOutside(domConfig, (): void => configStore.close());
   font-size: var(--font-size-sm);
   opacity: 0.5;
   text-transform: uppercase;
+}
+
+.option-label {
+  font-style: italic;
+  margin-bottom: 0.3rem;
+  opacity: 0.6;
+}
+
+.buttons {
+  display: flex;
+  gap: 0.5rem;
 }
 
 .user {

--- a/src/components/config/ConfigStore.ts
+++ b/src/components/config/ConfigStore.ts
@@ -50,6 +50,10 @@ export const useConfig = defineStore("config", {
       this.theme = themeLabel === "light" ? themeLight : themeDark;
       this.theme.forEach((c: ThemeColor) => document.documentElement.style.setProperty(c.var, c.color));
     },
+
+    toggleTierListSideLabels(value: boolean) {
+      this.tierListSideLabels = value;
+    },
   },
 
   persist: {
@@ -62,5 +66,6 @@ export const useConfig = defineStore("config", {
     show: false,
     theme: themeDark,
     themeLabel: "dark",
+    tierListSideLabels: true,
   }),
 });

--- a/src/components/dialog/AddCollection.vue
+++ b/src/components/dialog/AddCollection.vue
@@ -1,9 +1,33 @@
 <template>
   <Dialog title="Create a collection" with-title>
-    <div class="wrap">
+    <form class="wrap" @submit.prevent="create()">
       <input v-model="collectionName" class="input" placeholder="Collection's name" type="text" />
-      <ButtonIndex variant="primary" @click="create()">Create</ButtonIndex>
-    </div>
+      <div class="option-list section">
+        <div class="option">
+          <label for="topRanking">Top ranking</label>
+          <div class="buttons">
+            <ButtonIndex :variant="!topEnabled ? 'primary' : 'default'" @click="topEnabled = false">Off</ButtonIndex>
+            <ButtonIndex :variant="topEnabled ? 'primary' : 'default'" @click="topEnabled = true">On</ButtonIndex>
+          </div>
+        </div>
+      </div>
+      <div v-if="topEnabled" class="option-list section">
+        <div class="option">
+          <label for="topPreset">Preset</label>
+          <div class="buttons">
+            <ButtonIndex
+              v-for="preset in TOP_PRESETS"
+              :key="preset.id"
+              :variant="isSelectedPreset(preset) ? 'primary' : 'default'"
+              @click="selectedTiers = preset.tiers"
+            >
+              {{ preset.label }}
+            </ButtonIndex>
+          </div>
+        </div>
+      </div>
+      <ButtonIndex type="submit" variant="primary">Create</ButtonIndex>
+    </form>
   </Dialog>
 </template>
 
@@ -15,20 +39,28 @@ import { useDialog } from "@/components/dialog/DialogStore";
 import Dialog from "@/components/dialog/DialogWrap.vue";
 import { useSidebar } from "@/components/sidebar/SidebarStore";
 import ButtonIndex from "@/components/ui/ButtonIndex.vue";
+import { TOP_PRESETS, TopPreset, TopTiers } from "@/helpers/collectionOptions";
 import { notification } from "@/helpers/notifications";
 
 const dialogStore = useDialog();
 const sidebarStore = useSidebar();
 const collectionName = ref("");
+const topEnabled = ref(false);
+const selectedTiers = ref<TopTiers>(TOP_PRESETS[1].tiers);
 
 async function create(): Promise<void> {
+  if (!collectionName.value.trim()) return;
   try {
-    await sidebarStore.addCollection(collectionName.value);
+    await sidebarStore.addCollection(collectionName.value, topEnabled.value ? selectedTiers.value : null);
     dialogStore.close();
     notification({ msg: `Collection ${collectionName.value} created`, type: NotificationType.Success });
   } catch {
     // handled upstream
   }
+}
+
+function isSelectedPreset(preset: TopPreset): boolean {
+  return preset.tiers.join("-") === selectedTiers.value.join("-");
 }
 </script>
 
@@ -51,6 +83,33 @@ async function create(): Promise<void> {
   margin-bottom: 1.2rem;
   outline: 0;
   padding: 0.8rem 1rem;
+  width: 100%;
+}
+
+.option-list {
+  display: flex;
+  justify-content: space-between;
+
+  .option {
+    flex: 1;
+  }
+}
+
+.section {
+  margin-bottom: 1.2rem;
+}
+
+.buttons {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+}
+
+label {
+  display: block;
+  font-style: italic;
+  margin-bottom: 0.3rem;
+  opacity: 0.6;
   width: 100%;
 }
 </style>

--- a/src/components/dialog/AddCollection.vue
+++ b/src/components/dialog/AddCollection.vue
@@ -2,30 +2,7 @@
   <Dialog title="Create a collection" with-title>
     <form class="wrap" @submit.prevent="create()">
       <input v-model="collectionName" class="input" placeholder="Collection's name" type="text" />
-      <div class="option-list section">
-        <div class="option">
-          <label for="topRanking">Top ranking</label>
-          <div class="buttons">
-            <ButtonIndex :variant="!topEnabled ? 'primary' : 'default'" @click="topEnabled = false">Off</ButtonIndex>
-            <ButtonIndex :variant="topEnabled ? 'primary' : 'default'" @click="topEnabled = true">On</ButtonIndex>
-          </div>
-        </div>
-      </div>
-      <div v-if="topEnabled" class="option-list section">
-        <div class="option">
-          <label for="topPreset">Preset</label>
-          <div class="buttons">
-            <ButtonIndex
-              v-for="preset in TOP_PRESETS"
-              :key="preset.id"
-              :variant="isSelectedPreset(preset) ? 'primary' : 'default'"
-              @click="selectedTiers = preset.tiers"
-            >
-              {{ preset.label }}
-            </ButtonIndex>
-          </div>
-        </div>
-      </div>
+      <RankingModeEditor v-model="rankingMode" />
       <ButtonIndex type="submit" variant="primary">Create</ButtonIndex>
     </form>
   </Dialog>
@@ -37,30 +14,26 @@ import { ref } from "vue";
 import { NotificationType } from "@/@types/Notification";
 import { useDialog } from "@/components/dialog/DialogStore";
 import Dialog from "@/components/dialog/DialogWrap.vue";
+import RankingModeEditor from "@/components/dialog/RankingModeEditor.vue";
 import { useSidebar } from "@/components/sidebar/SidebarStore";
 import ButtonIndex from "@/components/ui/ButtonIndex.vue";
-import { TOP_PRESETS, TopPreset, TopTiers } from "@/helpers/collectionOptions";
+import { CollectionRankingMode } from "@/helpers/collectionOptions";
 import { notification } from "@/helpers/notifications";
 
 const dialogStore = useDialog();
 const sidebarStore = useSidebar();
 const collectionName = ref("");
-const topEnabled = ref(false);
-const selectedTiers = ref<TopTiers>(TOP_PRESETS[1].tiers);
+const rankingMode = ref<CollectionRankingMode>({ type: "off" });
 
 async function create(): Promise<void> {
   if (!collectionName.value.trim()) return;
   try {
-    await sidebarStore.addCollection(collectionName.value, topEnabled.value ? selectedTiers.value : null);
+    await sidebarStore.addCollection(collectionName.value, rankingMode.value);
     dialogStore.close();
     notification({ msg: `Collection ${collectionName.value} created`, type: NotificationType.Success });
   } catch {
     // handled upstream
   }
-}
-
-function isSelectedPreset(preset: TopPreset): boolean {
-  return preset.tiers.join("-") === selectedTiers.value.join("-");
 }
 </script>
 
@@ -83,33 +56,6 @@ function isSelectedPreset(preset: TopPreset): boolean {
   margin-bottom: 1.2rem;
   outline: 0;
   padding: 0.8rem 1rem;
-  width: 100%;
-}
-
-.option-list {
-  display: flex;
-  justify-content: space-between;
-
-  .option {
-    flex: 1;
-  }
-}
-
-.section {
-  margin-bottom: 1.2rem;
-}
-
-.buttons {
-  display: flex;
-  gap: 0.5rem;
-  justify-content: center;
-}
-
-label {
-  display: block;
-  font-style: italic;
-  margin-bottom: 0.3rem;
-  opacity: 0.6;
   width: 100%;
 }
 </style>

--- a/src/components/dialog/DialogStore.ts
+++ b/src/components/dialog/DialogStore.ts
@@ -1,10 +1,12 @@
 import { defineStore } from "pinia";
 
 import { Dialog, DialogType, UpdatePlaylistValues } from "@/@types/Dialog";
+import { NotificationType } from "@/@types/Notification";
 import { Track, TrackSimplified } from "@/@types/Track";
 import { instance } from "@/api";
 import { useSidebar } from "@/components/sidebar/SidebarStore";
-import { buildCollectionDescription } from "@/helpers/collectionOptions";
+import { buildCollectionDescription, MAX_DESCRIPTION_LENGTH } from "@/helpers/collectionOptions";
+import { notification } from "@/helpers/notifications";
 import router from "@/router";
 import { usePlaylist } from "@/views/playlist/PlaylistStore";
 
@@ -44,7 +46,14 @@ export const useDialog = defineStore("dialog", {
     },
 
     async updatePlaylist(value: UpdatePlaylistValues, playlistId: string | undefined, isCollection: boolean) {
-      const builtDescription = buildCollectionDescription(value.description, isCollection, value.topTiers);
+      const builtDescription = buildCollectionDescription(value.description, isCollection, value.rankingMode);
+      if (builtDescription.length > MAX_DESCRIPTION_LENGTH) {
+        notification({
+          msg: `Description too long (${builtDescription.length}/${MAX_DESCRIPTION_LENGTH} characters). Shorten the text or the tier list.`,
+          type: NotificationType.Error,
+        });
+        return;
+      }
       const data = {
         collaborative: value.collaborative,
         description: builtDescription === "" ? "No description" : builtDescription,
@@ -71,7 +80,7 @@ export const useDialog = defineStore("dialog", {
       }
     },
 
-    updatePlaylistCurrentPage(value: Omit<UpdatePlaylistValues, "topTiers">, playlistId: string | undefined) {
+    updatePlaylistCurrentPage(value: Omit<UpdatePlaylistValues, "rankingMode">, playlistId: string | undefined) {
       const playlistStore = usePlaylist();
       if (router.currentRoute.value.params.id === playlistId) {
         playlistStore.playlist.description = value.description;

--- a/src/components/dialog/DialogStore.ts
+++ b/src/components/dialog/DialogStore.ts
@@ -4,6 +4,7 @@ import { Dialog, DialogType, UpdatePlaylistValues } from "@/@types/Dialog";
 import { Track, TrackSimplified } from "@/@types/Track";
 import { instance } from "@/api";
 import { useSidebar } from "@/components/sidebar/SidebarStore";
+import { buildCollectionDescription } from "@/helpers/collectionOptions";
 import router from "@/router";
 import { usePlaylist } from "@/views/playlist/PlaylistStore";
 
@@ -43,10 +44,11 @@ export const useDialog = defineStore("dialog", {
     },
 
     async updatePlaylist(value: UpdatePlaylistValues, playlistId: string | undefined, isCollection: boolean) {
+      const builtDescription = buildCollectionDescription(value.description, isCollection, value.topTiers);
       const data = {
         collaborative: value.collaborative,
-        description: value.description === "" ? "No description" : value.description,
-        name: isCollection ? `#Collection ${value.name}` : value.name,
+        description: builtDescription === "" ? "No description" : builtDescription,
+        name: value.name,
         public: value.public,
       };
 
@@ -69,7 +71,7 @@ export const useDialog = defineStore("dialog", {
       }
     },
 
-    updatePlaylistCurrentPage(value: UpdatePlaylistValues, playlistId: string | undefined) {
+    updatePlaylistCurrentPage(value: Omit<UpdatePlaylistValues, "topTiers">, playlistId: string | undefined) {
       const playlistStore = usePlaylist();
       if (router.currentRoute.value.params.id === playlistId) {
         playlistStore.playlist.description = value.description;

--- a/src/components/dialog/EditPlaylist.vue
+++ b/src/components/dialog/EditPlaylist.vue
@@ -65,47 +65,18 @@
             </div>
           </div>
         </div>
-        <div v-if="isEditable && isCollection" class="option-list section">
-          <div class="option">
-            <label for="topRanking">Top ranking</label>
-            <div class="buttons">
-              <ButtonIndex :variant="!topEnabled ? 'primary' : 'default'" @click="topEnabled = false">
-                Off
-              </ButtonIndex>
-              <ButtonIndex :variant="topEnabled ? 'primary' : 'default'" @click="topEnabled = true">
-                On
-              </ButtonIndex>
-            </div>
-          </div>
-        </div>
-        <div v-if="isEditable && isCollection && topEnabled" class="option-list section">
-          <div class="option">
-            <label for="topPreset">Preset</label>
-            <div class="buttons">
-              <ButtonIndex
-                v-for="preset in TOP_PRESETS"
-                :key="preset.id"
-                :variant="isSelectedPreset(preset) ? 'primary' : 'default'"
-                @click="selectedTiers = preset.tiers"
-              >
-                {{ preset.label }}
-              </ButtonIndex>
-            </div>
-          </div>
-        </div>
+        <RankingModeEditor
+          v-if="isEditable && isCollection"
+          v-model="values.rankingMode"
+          :description-text="values.description"
+        />
       </div>
       <div class="actions">
         <ButtonIndex @click="remove()">Delete {{ isCollection ? "collection" : "playlist" }}</ButtonIndex>
         <ButtonIndex
           v-if="isEditable"
           variant="primary"
-          @click="
-            dialogStore.updatePlaylist(
-              { ...values, topTiers: topEnabled ? selectedTiers : null },
-              dialogStore.playlistId,
-              isCollection,
-            )
-          "
+          @click="dialogStore.updatePlaylist(values, dialogStore.playlistId, isCollection)"
         >
           Confirm
         </ButtonIndex>
@@ -127,10 +98,11 @@ import { Playlist } from "@/@types/Playlist";
 import { instance } from "@/api";
 import { useDialog } from "@/components/dialog/DialogStore";
 import Dialog from "@/components/dialog/DialogWrap.vue";
+import RankingModeEditor from "@/components/dialog/RankingModeEditor.vue";
 import { useSidebar } from "@/components/sidebar/SidebarStore";
 import ButtonIndex from "@/components/ui/ButtonIndex.vue";
 import Loading from "@/components/ui/LoadingDots.vue";
-import { parseTopTiers, stripCollectionTags, TOP_PRESETS, TopPreset, TopTiers } from "@/helpers/collectionOptions";
+import { parseCollectionRankingMode, stripCollectionTags } from "@/helpers/collectionOptions";
 import { isACollection } from "@/helpers/isCollection";
 import { isTouchDevice } from "@/helpers/isTouchDevice";
 import { notification } from "@/helpers/notifications";
@@ -147,16 +119,10 @@ const values: UpdatePlaylistValues = reactive({
   description: "",
   name: "",
   public: false,
-  topTiers: null,
+  rankingMode: { type: "off" },
 });
 const isCollection = ref<boolean>(false);
 const isEditable = ref<boolean>(false);
-const topEnabled = ref<boolean>(false);
-const selectedTiers = ref<TopTiers>(TOP_PRESETS[1].tiers);
-
-function isSelectedPreset(preset: TopPreset): boolean {
-  return preset.tiers.join("-") === selectedTiers.value.join("-");
-}
 
 watchEffect(async () => {
   if (dialogStore.show && dialogStore.type === "editPlaylist") {
@@ -169,9 +135,7 @@ watchEffect(async () => {
       values.description = cleanDescription === "No description" ? "" : cleanDescription;
       values.public = data.public;
       values.collaborative = data.collaborative;
-      const tiers = parseTopTiers(data.description);
-      topEnabled.value = tiers !== null;
-      selectedTiers.value = tiers ?? TOP_PRESETS[1].tiers;
+      values.rankingMode = parseCollectionRankingMode(data.description);
     } catch {
       notification({ msg: "Unable to load playlist details", type: NotificationType.Error });
     }

--- a/src/components/dialog/EditPlaylist.vue
+++ b/src/components/dialog/EditPlaylist.vue
@@ -65,13 +65,47 @@
             </div>
           </div>
         </div>
+        <div v-if="isEditable && isCollection" class="option-list section">
+          <div class="option">
+            <label for="topRanking">Top ranking</label>
+            <div class="buttons">
+              <ButtonIndex :variant="!topEnabled ? 'primary' : 'default'" @click="topEnabled = false">
+                Off
+              </ButtonIndex>
+              <ButtonIndex :variant="topEnabled ? 'primary' : 'default'" @click="topEnabled = true">
+                On
+              </ButtonIndex>
+            </div>
+          </div>
+        </div>
+        <div v-if="isEditable && isCollection && topEnabled" class="option-list section">
+          <div class="option">
+            <label for="topPreset">Preset</label>
+            <div class="buttons">
+              <ButtonIndex
+                v-for="preset in TOP_PRESETS"
+                :key="preset.id"
+                :variant="isSelectedPreset(preset) ? 'primary' : 'default'"
+                @click="selectedTiers = preset.tiers"
+              >
+                {{ preset.label }}
+              </ButtonIndex>
+            </div>
+          </div>
+        </div>
       </div>
       <div class="actions">
         <ButtonIndex @click="remove()">Delete {{ isCollection ? "collection" : "playlist" }}</ButtonIndex>
         <ButtonIndex
           v-if="isEditable"
           variant="primary"
-          @click="dialogStore.updatePlaylist(values, dialogStore.playlistId, isCollection)"
+          @click="
+            dialogStore.updatePlaylist(
+              { ...values, topTiers: topEnabled ? selectedTiers : null },
+              dialogStore.playlistId,
+              isCollection,
+            )
+          "
         >
           Confirm
         </ButtonIndex>
@@ -96,6 +130,8 @@ import Dialog from "@/components/dialog/DialogWrap.vue";
 import { useSidebar } from "@/components/sidebar/SidebarStore";
 import ButtonIndex from "@/components/ui/ButtonIndex.vue";
 import Loading from "@/components/ui/LoadingDots.vue";
+import { parseTopTiers, stripCollectionTags, TOP_PRESETS, TopPreset, TopTiers } from "@/helpers/collectionOptions";
+import { isACollection } from "@/helpers/isCollection";
 import { isTouchDevice } from "@/helpers/isTouchDevice";
 import { notification } from "@/helpers/notifications";
 import { useAuth } from "@/views/auth/AuthStore";
@@ -111,20 +147,31 @@ const values: UpdatePlaylistValues = reactive({
   description: "",
   name: "",
   public: false,
+  topTiers: null,
 });
 const isCollection = ref<boolean>(false);
 const isEditable = ref<boolean>(false);
+const topEnabled = ref<boolean>(false);
+const selectedTiers = ref<TopTiers>(TOP_PRESETS[1].tiers);
+
+function isSelectedPreset(preset: TopPreset): boolean {
+  return preset.tiers.join("-") === selectedTiers.value.join("-");
+}
 
 watchEffect(async () => {
   if (dialogStore.show && dialogStore.type === "editPlaylist") {
     try {
       const { data } = await instance().get<Playlist>(`playlists/${dialogStore.playlistId}`);
       isEditable.value = data.owner.id === useAuth().me?.id;
-      isCollection.value = data.name.toLowerCase().startsWith("#collection");
-      values.name = data.name.replaceAll("#Collection ", "");
-      values.description = data.description === "" || data.description === "No description" ? "" : data.description;
+      isCollection.value = isACollection(data);
+      values.name = data.name;
+      const cleanDescription = stripCollectionTags(data.description);
+      values.description = cleanDescription === "No description" ? "" : cleanDescription;
       values.public = data.public;
       values.collaborative = data.collaborative;
+      const tiers = parseTopTiers(data.description);
+      topEnabled.value = tiers !== null;
+      selectedTiers.value = tiers ?? TOP_PRESETS[1].tiers;
     } catch {
       notification({ msg: "Unable to load playlist details", type: NotificationType.Error });
     }

--- a/src/components/dialog/RankingModeEditor.vue
+++ b/src/components/dialog/RankingModeEditor.vue
@@ -51,7 +51,7 @@ function defaultTierList(): TierList {
   return [
     { label: "S", size: 0 },
     { label: "A", size: 0 },
-    { label: "B", size: null },
+    { label: "B", size: 0 },
   ];
 }
 

--- a/src/components/dialog/RankingModeEditor.vue
+++ b/src/components/dialog/RankingModeEditor.vue
@@ -1,0 +1,124 @@
+<template>
+  <div class="option-list section">
+    <div class="option">
+      <label for="rankingMode">Ranking</label>
+      <div class="buttons">
+        <ButtonIndex :variant="modeType === 'off' ? 'primary' : 'default'" @click="setMode('off')">Off</ButtonIndex>
+        <ButtonIndex :variant="modeType === 'top' ? 'primary' : 'default'" @click="setMode('top')">Top</ButtonIndex>
+        <ButtonIndex :variant="modeType === 'tierlist' ? 'primary' : 'default'" @click="setMode('tierlist')">
+          Tier list
+        </ButtonIndex>
+      </div>
+    </div>
+  </div>
+  <div v-if="modeType === 'top'" class="option-list section">
+    <div class="option">
+      <label for="topPreset">Preset</label>
+      <div class="buttons">
+        <ButtonIndex
+          v-for="preset in TOP_PRESETS"
+          :key="preset.id"
+          :variant="isSelectedPreset(preset) ? 'primary' : 'default'"
+          @click="selectPreset(preset)"
+        >
+          {{ preset.label }}
+        </ButtonIndex>
+      </div>
+    </div>
+  </div>
+  <div v-else-if="modeType === 'tierlist'" class="section">
+    <TierEditor
+      :description-text="descriptionText"
+      :model-value="tierListTiers"
+      @update:model-value="handleTierListChange"
+    />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref, watch } from "vue";
+
+import TierEditor from "@/components/dialog/TierEditor.vue";
+import ButtonIndex from "@/components/ui/ButtonIndex.vue";
+import { CollectionRankingMode, TierList, TOP_PRESETS, TopPreset, TopTiers } from "@/helpers/collectionOptions";
+
+const props = withDefaults(defineProps<{ descriptionText?: string; modelValue: CollectionRankingMode }>(), {
+  descriptionText: "",
+});
+const emit = defineEmits<{ "update:modelValue": [value: CollectionRankingMode] }>();
+
+function defaultTierList(): TierList {
+  return [
+    { label: "S", size: 0 },
+    { label: "A", size: 0 },
+    { label: "B", size: null },
+  ];
+}
+
+const modeType = ref(props.modelValue.type);
+const topTiers = ref<TopTiers>(props.modelValue.type === "top" ? props.modelValue.tiers : TOP_PRESETS[1].tiers);
+const tierListTiers = ref<TierList>(props.modelValue.type === "tierlist" ? props.modelValue.tiers : defaultTierList());
+
+watch(
+  () => props.modelValue,
+  (value) => {
+    modeType.value = value.type;
+    if (value.type === "top") topTiers.value = value.tiers;
+    if (value.type === "tierlist") tierListTiers.value = value.tiers;
+  },
+);
+
+function commit(): void {
+  if (modeType.value === "top") emit("update:modelValue", { tiers: topTiers.value, type: "top" });
+  else if (modeType.value === "tierlist") emit("update:modelValue", { tiers: tierListTiers.value, type: "tierlist" });
+  else emit("update:modelValue", { type: "off" });
+}
+
+function handleTierListChange(value: TierList): void {
+  tierListTiers.value = value;
+  commit();
+}
+
+function isSelectedPreset(preset: TopPreset): boolean {
+  return preset.tiers.join("-") === topTiers.value.join("-");
+}
+
+function selectPreset(preset: TopPreset): void {
+  topTiers.value = preset.tiers;
+  commit();
+}
+
+function setMode(mode: CollectionRankingMode["type"]): void {
+  modeType.value = mode;
+  commit();
+}
+</script>
+
+<style lang="scss" scoped>
+.option-list {
+  display: flex;
+  justify-content: space-between;
+
+  .option {
+    flex: 1;
+  }
+}
+
+.section {
+  margin-bottom: 1.2rem;
+}
+
+.buttons {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+}
+
+label {
+  display: block;
+  font-style: italic;
+  margin-bottom: 0.3rem;
+  opacity: 0.6;
+  width: 100%;
+}
+</style>

--- a/src/components/dialog/TierEditor.vue
+++ b/src/components/dialog/TierEditor.vue
@@ -1,18 +1,29 @@
 <template>
   <div class="tier-editor">
-    <div v-for="(tier, index) in tiers" :key="index" class="tier-row">
-      <span class="tier-color" :style="{ backgroundColor: getTierColor(index, tiers.length) }" />
-      <input v-model="tier.label" class="input tier-label" placeholder="Name" type="text" @input="commit" />
-      <button
-        class="remove"
-        :disabled="tiers.length <= 1"
-        title="Remove category"
-        type="button"
-        @click="removeTier(index)"
-      >
-        ×
-      </button>
-    </div>
+    <VueDraggable
+      v-model="tiers"
+      :animation="150"
+      class="tier-list"
+      :delay="150"
+      force-fallback
+      handle=".tier-drag-handle"
+      @end="commit"
+    >
+      <div v-for="(tier, index) in tiers" :key="index" class="tier-row">
+        <i class="icon-menu tier-drag-handle" title="Drag to reorder" />
+        <span class="tier-color" :style="{ backgroundColor: getTierColor(index, tiers.length) }" />
+        <input v-model="tier.label" class="input tier-label" placeholder="Name" type="text" @input="commit" />
+        <button
+          class="remove"
+          :disabled="tiers.length <= 1"
+          title="Remove category"
+          type="button"
+          @click="removeTier(index)"
+        >
+          ×
+        </button>
+      </div>
+    </VueDraggable>
     <ButtonIndex variant="border" @click="addTier">+ Add category</ButtonIndex>
     <div class="budget" :class="{ over: remaining < 0 }">
       {{ remaining }} / {{ MAX_DESCRIPTION_LENGTH }} characters left
@@ -22,6 +33,7 @@
 
 <script lang="ts" setup>
 import { computed, ref, watch } from "vue";
+import { VueDraggable } from "vue-draggable-plus";
 
 import ButtonIndex from "@/components/ui/ButtonIndex.vue";
 import {
@@ -51,7 +63,7 @@ const remaining = computed(() =>
 );
 
 function addTier(): void {
-  tiers.value.splice(tiers.value.length - 1, 0, { label: "", size: 0 });
+  tiers.value.push({ label: "", size: 0 });
   commit();
 }
 
@@ -75,10 +87,27 @@ function removeTier(index: number): void {
   gap: 0.6rem;
 }
 
+.tier-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
 .tier-row {
   align-items: center;
   display: flex;
   gap: 0.5rem;
+}
+
+.tier-drag-handle {
+  color: currentcolor;
+  cursor: grab;
+  flex-shrink: 0;
+  opacity: 0.4;
+
+  &:hover {
+    opacity: 0.8;
+  }
 }
 
 .tier-color {

--- a/src/components/dialog/TierEditor.vue
+++ b/src/components/dialog/TierEditor.vue
@@ -1,0 +1,138 @@
+<template>
+  <div class="tier-editor">
+    <div v-for="(tier, index) in tiers" :key="index" class="tier-row">
+      <span class="tier-color" :style="{ backgroundColor: getTierColor(index, tiers.length) }" />
+      <input v-model="tier.label" class="input tier-label" placeholder="Name" type="text" @input="commit" />
+      <button
+        class="remove"
+        :disabled="tiers.length <= 1"
+        title="Remove category"
+        type="button"
+        @click="removeTier(index)"
+      >
+        ×
+      </button>
+    </div>
+    <ButtonIndex variant="border" @click="addTier">+ Add category</ButtonIndex>
+    <div class="budget" :class="{ over: remaining < 0 }">
+      {{ remaining }} / {{ MAX_DESCRIPTION_LENGTH }} characters left
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computed, ref, watch } from "vue";
+
+import ButtonIndex from "@/components/ui/ButtonIndex.vue";
+import {
+  buildCollectionDescription,
+  getTierColor,
+  MAX_DESCRIPTION_LENGTH,
+  remainingDescriptionBudget,
+  TierList,
+} from "@/helpers/collectionOptions";
+
+const props = withDefaults(defineProps<{ descriptionText?: string; modelValue: TierList }>(), {
+  descriptionText: "",
+});
+const emit = defineEmits<{ "update:modelValue": [value: TierList] }>();
+
+const tiers = ref<TierList>(props.modelValue);
+
+watch(
+  () => props.modelValue,
+  (value) => {
+    tiers.value = value;
+  },
+);
+
+const remaining = computed(() =>
+  remainingDescriptionBudget(buildCollectionDescription(props.descriptionText, true, { tiers: tiers.value, type: "tierlist" })),
+);
+
+function addTier(): void {
+  tiers.value.splice(tiers.value.length - 1, 0, { label: "", size: 0 });
+  commit();
+}
+
+function commit(): void {
+  emit("update:modelValue", tiers.value);
+}
+
+function removeTier(index: number): void {
+  if (tiers.value.length <= 1) return;
+  tiers.value.splice(index, 1);
+  commit();
+}
+</script>
+
+<style lang="scss" scoped>
+@use "@/assets/scss/mixins" as *;
+
+.tier-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.tier-row {
+  align-items: center;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.tier-color {
+  border-radius: 50%;
+  flex-shrink: 0;
+  height: 1.2rem;
+  width: 1.2rem;
+}
+
+.input {
+  @include font-bold;
+
+  background-color: var(--bg-color-light);
+  border: 0;
+  border-radius: 0.3rem;
+  color: currentcolor;
+  outline: 0;
+  padding: 0.6rem 0.8rem;
+}
+
+.tier-label {
+  flex: 1;
+}
+
+.remove {
+  background: none;
+  border: 0;
+  border-radius: 0.3rem;
+  color: currentcolor;
+  cursor: pointer;
+  font-size: var(--font-size-lg);
+  line-height: 1;
+  opacity: 0.6;
+  padding: 0.4rem 0.6rem;
+
+  &:hover:not(:disabled) {
+    background-color: var(--bg-color-light);
+    opacity: 1;
+  }
+
+  &:disabled {
+    cursor: default;
+    opacity: 0.2;
+  }
+}
+
+.budget {
+  font-size: var(--font-size-sm);
+  opacity: 0.6;
+  text-align: right;
+
+  &.over {
+    color: rgb(185 50 50);
+    opacity: 1;
+  }
+}
+</style>

--- a/src/components/playlist/PlaylistHeader.vue
+++ b/src/components/playlist/PlaylistHeader.vue
@@ -18,13 +18,8 @@
           <span>&nbsp;·&nbsp;{{ playlistStore.playlist.tracks.total }} items</span>
           <span v-if="!noDuration">&nbsp;·&nbsp;{{ timecodeWithUnits(sumDuration(playlistStore.tracks)) }}</span>
         </div>
-        <div
-          v-if="
-            playlistStore.playlist.description !== 'null' && playlistStore.playlist.description !== 'No description'
-          "
-          class="description"
-        >
-          {{ playlistStore.playlist.description }}
+        <div v-if="showDescription" class="description">
+          {{ visibleDescription }}
         </div>
       </div>
     </div>
@@ -37,6 +32,15 @@
         placeholder="Filter..."
         type="search"
       />
+      <ButtonIndex
+        v-if="showMigrateButton"
+        :title="migrateButtonTooltip"
+        variant="border"
+        @click="playlistStore.migrateLegacyCollectionTag()"
+      >
+        <i class="icon-folder" />
+        Convert to new collection format
+      </ButtonIndex>
       <ButtonIndex
         v-if="canShare"
         icon-only
@@ -60,7 +64,9 @@ import { useDialog } from "@/components/dialog/DialogStore";
 import Actions from "@/components/playlist/PlaylistActions.vue";
 import Cover from "@/components/ui/AlbumCover.vue";
 import ButtonIndex from "@/components/ui/ButtonIndex.vue";
+import { stripCollectionTags } from "@/helpers/collectionOptions";
 import { timecodeWithUnits } from "@/helpers/date";
+import { isLegacyCollectionName } from "@/helpers/isCollection";
 import { isPlaylistOwner } from "@/helpers/playlist";
 import { usePlaylist } from "@/views/playlist/PlaylistStore";
 
@@ -81,6 +87,19 @@ const canShare = computed<boolean>(
     route.name === "Collection"
     && playlistStore.playlist.public
     && isPlaylistOwner(playlistStore.playlist.owner),
+);
+const showMigrateButton = computed<boolean>(
+  () => isPlaylistOwner(playlistStore.playlist.owner) && isLegacyCollectionName(playlistStore.playlist),
+);
+const migrateButtonTooltip
+  = "This collection still uses the old #Collection tag in its name. Beardify now reads it from the description "
+    + "instead — click to convert it automatically.";
+const visibleDescription = computed<string>(() => stripCollectionTags(playlistStore.playlist.description));
+const showDescription = computed<boolean>(
+  () =>
+    visibleDescription.value !== ""
+    && visibleDescription.value !== "null"
+    && visibleDescription.value !== "No description",
 );
 
 onMounted(() => {

--- a/src/components/playlist/PlaylistHeader.vue
+++ b/src/components/playlist/PlaylistHeader.vue
@@ -159,7 +159,7 @@ function sumDuration(tracks: PlaylistTrack[]): number {
 }
 
 .playlist-header {
-  $padd: 10rem;
+  $padd: 5rem;
 
   display: flex;
   justify-content: space-between;

--- a/src/components/playlist/TierRow.vue
+++ b/src/components/playlist/TierRow.vue
@@ -1,0 +1,218 @@
+<template>
+  <div class="tier-row" :class="{ 'tier-row-side': sideLayout, 'tier-row-unsorted': scrollable }">
+    <div
+      class="tier-heading"
+      :class="{ 'tier-heading-colored': !!color, 'tier-heading-unsorted': unsorted, 'tier-heading-side': sideLayout }"
+      :style="color ? { backgroundColor: color } : undefined"
+    >
+      {{ label }}
+    </div>
+    <div v-if="scrollable" class="unsorted-scroll-wrap">
+      <button
+        class="scroll-arrow"
+        :disabled="!canScrollLeft"
+        title="Scroll left"
+        type="button"
+        @click="scroll(-1)"
+      >
+        <i class="icon-arrow-left" />
+      </button>
+      <div ref="scrollRef" class="unsorted-scroll" @scroll="updateScrollState">
+        <slot />
+      </div>
+      <button
+        class="scroll-arrow"
+        :disabled="!canScrollRight"
+        title="Scroll right"
+        type="button"
+        @click="scroll(1)"
+      >
+        <i class="icon-arrow-right" />
+      </button>
+    </div>
+    <slot v-else />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { onBeforeUnmount, onMounted, ref } from "vue";
+
+withDefaults(
+  defineProps<{
+    color?: string;
+    label: string;
+    scrollable?: boolean;
+    sideLayout?: boolean;
+    unsorted?: boolean;
+  }>(),
+  { color: undefined, scrollable: false, sideLayout: false, unsorted: false },
+);
+
+const scrollRef = ref<HTMLElement | null>(null);
+const canScrollLeft = ref(false);
+const canScrollRight = ref(false);
+let resizeObserver: null | ResizeObserver = null;
+
+function scroll(direction: -1 | 1): void {
+  const el = scrollRef.value;
+  if (!el) return;
+  el.scrollBy({ behavior: "smooth", left: direction * el.clientWidth * 0.9 });
+}
+
+function updateScrollState(): void {
+  const el = scrollRef.value;
+  if (!el) return;
+  canScrollLeft.value = el.scrollLeft > 0;
+  canScrollRight.value = el.scrollLeft + el.clientWidth < el.scrollWidth - 1;
+}
+
+// Watches the slotted grid's own box (not the scroll container's, which stays
+// a fixed size) so the arrows update whenever content is added/removed or the
+// window resizes, without the parent having to notify us explicitly.
+onMounted(() => {
+  const container = scrollRef.value;
+  if (!container) return;
+  updateScrollState();
+  resizeObserver = new ResizeObserver(updateScrollState);
+  resizeObserver.observe(container.firstElementChild ?? container);
+});
+
+onBeforeUnmount(() => resizeObserver?.disconnect());
+</script>
+
+<style lang="scss" scoped>
+@use "@/assets/scss/mixins" as *;
+@use "@/assets/scss/responsive" as responsive;
+
+.tier-row {
+  display: contents;
+}
+
+.tier-row-side {
+  align-items: stretch;
+  display: flex;
+  margin-bottom: 1.5rem;
+}
+
+// Sticky requires an actual box (display: contents, used by .tier-row, opts an
+// element out of sticky positioning entirely), so the scrollable row gets its
+// own always-boxed variant instead of reusing .tier-row.
+.tier-row-unsorted {
+  background-color: var(--bg-color-darker);
+  bottom: 0;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  padding-bottom: 1rem;
+  position: sticky;
+  z-index: 2;
+
+  &.tier-row-side {
+    flex-direction: row;
+  }
+
+  &::before {
+    background-image: linear-gradient(to top, var(--bg-color-darker) 0%, transparent 100%);
+    bottom: 100%;
+    content: "";
+    height: 20px;
+    left: 0;
+    pointer-events: none;
+    position: absolute;
+    right: 0;
+  }
+}
+
+.tier-heading {
+  background-color: var(--bg-color);
+  border-radius: 0.4rem;
+  font-size: var(--font-size-lg);
+  line-break: anywhere;
+  margin: 2rem 0 1rem;
+  padding: 0.7rem 1.2rem;
+
+  @include font-bold;
+
+  &:first-child {
+    margin-top: 0;
+  }
+}
+
+.tier-heading-colored {
+  color: #fff;
+  text-shadow: 0 0.1rem 0.2rem rgb(0 0 0 / 40%);
+}
+
+.tier-heading-unsorted {
+  background-color: transparent;
+  border: 0.1rem dashed var(--bg-color-lighter);
+  color: var(--font-color-dark);
+  font-style: italic;
+  opacity: 0.7;
+}
+
+.tier-heading-side {
+  align-items: center;
+  border-radius: 0.4rem 0 0 0.4rem;
+  display: flex;
+  flex-shrink: 0;
+  justify-content: center;
+  margin: 0;
+  text-align: center;
+  width: 8rem;
+
+  @include responsive.mobile {
+    width: 5rem;
+  }
+}
+
+.unsorted-scroll-wrap {
+  align-items: center;
+  background-color: var(--bg-color);
+  border-radius: 0 0.4rem 0.4rem 0;
+  display: flex;
+  flex: 1;
+  gap: 0.5rem;
+  min-width: 0;
+  padding: 0 1rem;
+}
+
+// flex + min-width: 0 are required here: flex items default to min-width:
+// auto, which without this would let the grid's intrinsic content width blow
+// out the container instead of scrolling inside it.
+.unsorted-scroll {
+  flex: 1;
+  min-width: 0;
+  overflow-x: auto;
+  scroll-behavior: smooth;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+.scroll-arrow {
+  align-items: center;
+  background-color: var(--bg-color-light);
+  border: 0;
+  border-radius: 50%;
+  color: currentcolor;
+  cursor: pointer;
+  display: flex;
+  flex-shrink: 0;
+  font-size: var(--font-size-lg);
+  height: 2.4rem;
+  justify-content: center;
+  width: 2.4rem;
+
+  &:hover:not(:disabled) {
+    background-color: var(--bg-color-lighter);
+  }
+
+  &:disabled {
+    cursor: default;
+    opacity: 0.3;
+  }
+}
+</style>

--- a/src/components/sidebar/PlaylistIcon.vue
+++ b/src/components/sidebar/PlaylistIcon.vue
@@ -1,22 +1,22 @@
 <template>
   <i
-    v-if="authStore.me?.id === playlist.owner.id && !playlist.name.includes('#Collection')"
+    v-if="authStore.me?.id === playlist.owner.id && !isACollection(playlist)"
     class="type-icon icon-music"
   />
   <i
     v-if="
       authStore.me?.id !== playlist.owner.id &&
       playlist.owner.display_name !== 'Spotify' &&
-      !playlist.name.includes('#Collection')
+      !isACollection(playlist)
     "
     class="type-icon others icon-music"
   />
   <i
-    v-if="authStore.me?.id === playlist.owner.id && playlist.name.includes('#Collection')"
+    v-if="authStore.me?.id === playlist.owner.id && isACollection(playlist)"
     class="type-icon icon-folder"
   />
   <i
-    v-if="authStore.me?.id !== playlist.owner.id && playlist.name.includes('#Collection')"
+    v-if="authStore.me?.id !== playlist.owner.id && isACollection(playlist)"
     class="type-icon others icon-folder"
   />
   <i v-if="playlist.owner.display_name === 'Spotify'" class="type-icon icon-spotify" />
@@ -24,6 +24,7 @@
 
 <script lang="ts" setup>
 import { SimplifiedPlaylist } from "@/@types/Playlist";
+import { isACollection } from "@/helpers/isCollection";
 import { useAuth } from "@/views/auth/AuthStore";
 
 defineProps<{

--- a/src/components/sidebar/SidebarIndex.vue
+++ b/src/components/sidebar/SidebarIndex.vue
@@ -151,7 +151,7 @@ import { useSidebar } from "@/components/sidebar/SidebarStore";
 import VisibilityIcon from "@/components/sidebar/VisibilityIcon.vue";
 import ButtonIndex from "@/components/ui/ButtonIndex.vue";
 import Loader from "@/components/ui/LoadingDots.vue";
-import { parseTierList, parseTopTiers } from "@/helpers/collectionOptions";
+import { parseCollectionRankingMode } from "@/helpers/collectionOptions";
 import { useAuth } from "@/views/auth/AuthStore";
 
 const dialogStore = useDialog();
@@ -172,19 +172,24 @@ onClickOutside(collectionSearchInput, () => {
 
 watch(collectionSearchInput, () => collectionSearchInput.value && collectionSearchInput.value.focus());
 
-// Optimized: pre-computed filtered collections with memoized toLowerCase and displayName
-const filteredCollections = computed(() => {
-  const searchQuery = collectionSearchQuery.value.toLowerCase();
-
-  return sidebarStore.collections
-    .map((playlist) => ({
+// Parsed once per collections change, independent of the search query, so typing
+// in the filter box doesn't re-parse every description on each keystroke.
+const enrichedCollections = computed(() =>
+  sidebarStore.collections.map((playlist) => {
+    const mode = parseCollectionRankingMode(playlist.description);
+    return {
       ...playlist,
       displayName: playlist.name.replace("#Collection ", "").replace("#collection ", ""),
-      isTierList: parseTierList(playlist.description) !== null,
-      isTop: parseTopTiers(playlist.description) !== null,
+      isTierList: mode.type === "tierlist",
+      isTop: mode.type === "top",
       lowerName: playlist.name.toLowerCase(),
-    }))
-    .filter((playlist) => playlist.lowerName.includes(searchQuery));
+    };
+  }),
+);
+
+const filteredCollections = computed(() => {
+  const searchQuery = collectionSearchQuery.value.toLowerCase();
+  return enrichedCollections.value.filter((playlist) => playlist.lowerName.includes(searchQuery));
 });
 
 // Playlist search

--- a/src/components/sidebar/SidebarIndex.vue
+++ b/src/components/sidebar/SidebarIndex.vue
@@ -66,6 +66,7 @@
           <div class="name">
             {{ playlist.displayName }}
             <span v-if="playlist.isTop" class="top-badge" title="Top ranking enabled">TOP</span>
+            <span v-if="playlist.isTierList" class="tier-badge" title="Tier list enabled">TIER</span>
           </div>
           <VisibilityIcon :playlist="playlist" />
           <ButtonIndex
@@ -150,7 +151,7 @@ import { useSidebar } from "@/components/sidebar/SidebarStore";
 import VisibilityIcon from "@/components/sidebar/VisibilityIcon.vue";
 import ButtonIndex from "@/components/ui/ButtonIndex.vue";
 import Loader from "@/components/ui/LoadingDots.vue";
-import { parseTopTiers } from "@/helpers/collectionOptions";
+import { parseTierList, parseTopTiers } from "@/helpers/collectionOptions";
 import { useAuth } from "@/views/auth/AuthStore";
 
 const dialogStore = useDialog();
@@ -179,6 +180,7 @@ const filteredCollections = computed(() => {
     .map((playlist) => ({
       ...playlist,
       displayName: playlist.name.replace("#Collection ", "").replace("#collection ", ""),
+      isTierList: parseTierList(playlist.description) !== null,
       isTop: parseTopTiers(playlist.description) !== null,
       lowerName: playlist.name.toLowerCase(),
     }))
@@ -262,8 +264,8 @@ if ((authStore.me && !sidebarStore.collections.length) || !sidebarStore.playlist
     transition: transform 0.2s;
   }
 
+  .tier-badge,
   .top-badge {
-    background-color: var(--primary-color);
     border-radius: 0.3rem;
     color: white;
     font-size: 0.6rem;
@@ -271,6 +273,14 @@ if ((authStore.me && !sidebarStore.collections.length) || !sidebarStore.playlist
     margin-left: 0.4rem;
     padding: 0.1rem 0.3rem;
     vertical-align: middle;
+  }
+
+  .top-badge {
+    background-color: var(--primary-color);
+  }
+
+  .tier-badge {
+    background: linear-gradient(90deg, hsl(0deg 70% 40%), hsl(120deg 70% 40%));
   }
 
   &:hover {

--- a/src/components/sidebar/SidebarIndex.vue
+++ b/src/components/sidebar/SidebarIndex.vue
@@ -52,8 +52,8 @@
         />
       </div>
       <div v-if="!sidebarStore.collections.length" class="empty">
-        Oh well, you don't have a collection ! To create one, you just have to create one with + button or rename a
-        classic playlist but start with "#Collection". Magical, isn't it?
+        Oh well, you don't have a collection ! To create one, you just have to create one with + button or add
+        "#Collection" to a classic playlist's description. Magical, isn't it?
       </div>
       <div v-for="(playlist, index) in filteredCollections" v-else :key="index">
         <router-link
@@ -65,6 +65,7 @@
           <PlaylistIcon :playlist="playlist" />
           <div class="name">
             {{ playlist.displayName }}
+            <span v-if="playlist.isTop" class="top-badge" title="Top ranking enabled">TOP</span>
           </div>
           <VisibilityIcon :playlist="playlist" />
           <ButtonIndex
@@ -149,6 +150,7 @@ import { useSidebar } from "@/components/sidebar/SidebarStore";
 import VisibilityIcon from "@/components/sidebar/VisibilityIcon.vue";
 import ButtonIndex from "@/components/ui/ButtonIndex.vue";
 import Loader from "@/components/ui/LoadingDots.vue";
+import { parseTopTiers } from "@/helpers/collectionOptions";
 import { useAuth } from "@/views/auth/AuthStore";
 
 const dialogStore = useDialog();
@@ -177,6 +179,7 @@ const filteredCollections = computed(() => {
     .map((playlist) => ({
       ...playlist,
       displayName: playlist.name.replace("#Collection ", "").replace("#collection ", ""),
+      isTop: parseTopTiers(playlist.description) !== null,
       lowerName: playlist.name.toLowerCase(),
     }))
     .filter((playlist) => playlist.lowerName.includes(searchQuery));
@@ -257,6 +260,17 @@ if ((authStore.me && !sidebarStore.collections.length) || !sidebarStore.playlist
     flex: 1;
     text-align: left;
     transition: transform 0.2s;
+  }
+
+  .top-badge {
+    background-color: var(--primary-color);
+    border-radius: 0.3rem;
+    color: white;
+    font-size: 0.6rem;
+    letter-spacing: 0.03rem;
+    margin-left: 0.4rem;
+    padding: 0.1rem 0.3rem;
+    vertical-align: middle;
   }
 
   &:hover {

--- a/src/components/sidebar/SidebarStore.ts
+++ b/src/components/sidebar/SidebarStore.ts
@@ -5,7 +5,7 @@ import { Paging } from "@/@types/Paging";
 import { SimplifiedPlaylist } from "@/@types/Playlist";
 import { Sidebar } from "@/@types/Sidebar";
 import { instance } from "@/api";
-import { buildCollectionDescription, TopTiers } from "@/helpers/collectionOptions";
+import { buildCollectionDescription, CollectionRankingMode, MAX_DESCRIPTION_LENGTH } from "@/helpers/collectionOptions";
 import { isACollection } from "@/helpers/isCollection";
 import { removeFromLibrary } from "@/helpers/library";
 import { notification } from "@/helpers/notifications";
@@ -17,11 +17,19 @@ import { usePlaylist } from "@/views/playlist/PlaylistStore";
 
 export const useSidebar = defineStore("sidebar", {
   actions: {
-    async addCollection(name: string, topTiers: null | TopTiers = null) {
+    async addCollection(name: string, mode: CollectionRankingMode = { type: "off" }) {
+      const description = buildCollectionDescription("", true, mode);
+      if (description.length > MAX_DESCRIPTION_LENGTH) {
+        notification({
+          msg: `Description too long (${description.length}/${MAX_DESCRIPTION_LENGTH} characters). Shorten the tier list.`,
+          type: NotificationType.Error,
+        });
+        return;
+      }
       try {
         const authStore = useAuth();
         const { data } = await instance().post<SimplifiedPlaylist>(`users/${authStore.me?.id}/playlists`, {
-          description: buildCollectionDescription("", true, topTiers),
+          description,
           name,
         });
         this.collections = [data satisfies SimplifiedPlaylist, ...this.collections];

--- a/src/components/sidebar/SidebarStore.ts
+++ b/src/components/sidebar/SidebarStore.ts
@@ -5,6 +5,7 @@ import { Paging } from "@/@types/Paging";
 import { SimplifiedPlaylist } from "@/@types/Playlist";
 import { Sidebar } from "@/@types/Sidebar";
 import { instance } from "@/api";
+import { buildCollectionDescription, TopTiers } from "@/helpers/collectionOptions";
 import { isACollection } from "@/helpers/isCollection";
 import { removeFromLibrary } from "@/helpers/library";
 import { notification } from "@/helpers/notifications";
@@ -16,11 +17,11 @@ import { usePlaylist } from "@/views/playlist/PlaylistStore";
 
 export const useSidebar = defineStore("sidebar", {
   actions: {
-    async addCollection(name: string) {
+    async addCollection(name: string, topTiers: null | TopTiers = null) {
       try {
         const authStore = useAuth();
         const { data } = await instance().post<SimplifiedPlaylist>(`users/${authStore.me?.id}/playlists`, {
-          description: "#Collection",
+          description: buildCollectionDescription("", true, topTiers),
           name,
         });
         this.collections = [data satisfies SimplifiedPlaylist, ...this.collections];

--- a/src/components/sidebar/SidebarStore.ts
+++ b/src/components/sidebar/SidebarStore.ts
@@ -20,7 +20,8 @@ export const useSidebar = defineStore("sidebar", {
       try {
         const authStore = useAuth();
         const { data } = await instance().post<SimplifiedPlaylist>(`users/${authStore.me?.id}/playlists`, {
-          name: `#Collection ${name}`,
+          description: "#Collection",
+          name,
         });
         this.collections = [data satisfies SimplifiedPlaylist, ...this.collections];
       } catch {

--- a/src/components/ui/AlbumCover.vue
+++ b/src/components/ui/AlbumCover.vue
@@ -1,7 +1,7 @@
 <template>
-  <img v-if="size === 'small' && images.length >= 3" :src="images[2].url" loading="lazy" />
-  <img v-else-if="size === 'medium' && images.length >= 2" :src="images[1].url" loading="lazy" />
-  <img v-else-if="size === 'large' && images.length >= 1" :src="images[0].url" loading="lazy" />
+  <img v-if="size === 'small' && images && images.length >= 3" :src="images[2].url" loading="lazy" />
+  <img v-else-if="size === 'medium' && images && images.length >= 2" :src="images[1].url" loading="lazy" />
+  <img v-else-if="size === 'large' && images && images.length >= 1" :src="images[0].url" loading="lazy" />
   <img v-else src="/img/default.png" loading="lazy" />
 </template>
 
@@ -9,7 +9,7 @@
 import { Image, ImageSize } from "@/@types/Image";
 
 defineProps<{
-  images: Image[];
+  images: Image[] | null;
   size: ImageSize;
 }>();
 </script>

--- a/src/composables/useCollectionRanking.ts
+++ b/src/composables/useCollectionRanking.ts
@@ -1,0 +1,33 @@
+import { computed, ComputedRef, Ref } from "vue";
+
+import { AlbumSimplified } from "@/@types/Album";
+import { buildRankIndex, CollectionRankingMode, parseCollectionRankingMode, TierList, TopTiers } from "@/helpers/collectionOptions";
+
+export interface CollectionRanking {
+  rankingMode: ComputedRef<CollectionRankingMode>;
+  rankOf: (id: string) => number;
+  tierList: ComputedRef<null | TierList>;
+  topTiers: ComputedRef<null | TopTiers>;
+}
+
+/**
+ * Derives the ranking mode (Top / Tier list / off) and per-album rank from a
+ * playlist description and its current album order. Shared by CollectionPage
+ * and SharedCollectionPage — this half is pure/read-only in both; the actual
+ * tier groupings stay page-local since CollectionPage needs them as mutable
+ * refs (drag v-model targets) while SharedCollectionPage only ever reads them.
+ */
+export function useCollectionRanking(description: Ref<string>, albumList: Ref<AlbumSimplified[]>): CollectionRanking {
+  const rankingMode = computed(() => parseCollectionRankingMode(description.value));
+  const topTiers = computed<null | TopTiers>(() => (rankingMode.value.type === "top" ? rankingMode.value.tiers : null));
+  const tierList = computed<null | TierList>(() =>
+    rankingMode.value.type === "tierlist" ? rankingMode.value.tiers : null,
+  );
+  const rankIndex = computed(() => buildRankIndex(albumList.value));
+
+  function rankOf(id: string): number {
+    return (rankIndex.value.get(id) ?? -1) + 1;
+  }
+
+  return { rankingMode, rankOf, tierList, topTiers };
+}

--- a/src/helpers/arrayDiff.ts
+++ b/src/helpers/arrayDiff.ts
@@ -1,0 +1,14 @@
+/**
+ * Finds the single item that moved between two otherwise-identical lists by
+ * locating the first index where they diverge and tracing that item's prior
+ * position via its id.
+ */
+export function findMove<T extends { id: string }>(
+  previous: T[],
+  next: T[],
+): { newIndex: number; oldIndex: number } | null {
+  const newIndex = previous.findIndex((item, i) => item.id !== next[i]?.id);
+  if (newIndex === -1) return null;
+  const oldIndex = previous.findIndex((item) => item.id === next[newIndex].id);
+  return { newIndex, oldIndex };
+}

--- a/src/helpers/collectionOptions.ts
+++ b/src/helpers/collectionOptions.ts
@@ -181,6 +181,36 @@ export function sanitizeTierLabel(label: string): string {
   return label.replace(/[,=#\s]+/g, "_").replace(/^_+|_+$/g, "");
 }
 
+/**
+ * Given the tiers a set of now-deleted items used to belong to (looked up
+ * from their last known grouping), decrements each affected tier's stored
+ * size by how many of its items were removed. The last group in `groups` is
+ * the Unsorted bucket (see groupByTierList) — it's one entry longer than
+ * `list`, and never needs shrinking since it always absorbs whatever
+ * remains. Returns null if none of the removed ids belonged to a stored tier.
+ */
+export function shrinkTiersForRemovedAlbums<T extends { id: string }>(
+  list: TierList,
+  groups: T[][],
+  removedIds: string[],
+): null | TierList {
+  const tierIndexById = new Map<string, number>();
+  groups.forEach((group, tierIndex) => {
+    group.forEach((item) => tierIndexById.set(item.id, tierIndex));
+  });
+
+  const decrements = new Array<number>(list.length).fill(0);
+  let matched = false;
+  removedIds.forEach((id) => {
+    const tierIndex = tierIndexById.get(id);
+    if (tierIndex === undefined || tierIndex >= list.length) return;
+    decrements[tierIndex]++;
+    matched = true;
+  });
+  if (!matched) return null;
+  return list.map((tier, index) => ({ ...tier, size: Math.max(tier.size - decrements[index], 0) }));
+}
+
 /** Splits items into the 3 fixed "Top" buckets (big / medium / rest) by count. */
 export function splitTopTiers<T>(items: T[], tiers: TopTiers): [T[], T[], T[]] {
   const [big, medium] = tiers;

--- a/src/helpers/collectionOptions.ts
+++ b/src/helpers/collectionOptions.ts
@@ -5,6 +5,13 @@ const TIER_TAG_REGEX = /#tier:(\S+)/i;
 export const MAX_DESCRIPTION_LENGTH = 300;
 
 /**
+ * Label for the synthetic catch-all bucket newly added albums land in. It is
+ * not one of the user's editable categories and is never written to the
+ * `#Tier:` tag — it is always whatever comes after all stored tier sizes.
+ */
+export const UNSORTED_TIER_LABEL = "Unsorted";
+
+/**
  * A collection's ranking is either off, the fixed 3-tier "Top" mode (counts
  * only, auto-generated labels), or the free-form "Tier list" mode (custom
  * labels, arbitrary category count). The two modes are mutually exclusive —
@@ -56,12 +63,12 @@ export function buildCollectionDescription(
 
 /**
  * Encodes a tier list into the compact `#Tier:label=size,label=size,...` tag.
- * The last tier's size is always encoded as `*` (open-ended, takes the rest).
+ * Every category has an explicit, drag-managed size — none of them is an
+ * open catch-all. The catch-all is the separate, non-stored "Unsorted"
+ * bucket that newly added albums land in (see UNSORTED_TIER_LABEL).
  */
 export function buildTierTag(tiers: TierList): string {
-  const body = tiers
-    .map((tier, index) => `${sanitizeTierLabel(tier.label)}=${index === tiers.length - 1 ? "*" : tier.size}`)
-    .join(",");
+  const body = tiers.map((tier) => `${sanitizeTierLabel(tier.label)}=${tier.size ?? 0}`).join(",");
   return `#Tier:${body}`;
 }
 
@@ -86,7 +93,7 @@ export function displayTierLabel(label: string): string {
  */
 export function getTierColor(index: number, total: number): string {
   const hue = (index / Math.max(total - 1, 1)) * 120;
-  return `hsl(${hue} 70% 40%)`;
+  return `hsl(${hue} 70% 40% / 50%)`;
 }
 
 /**

--- a/src/helpers/collectionOptions.ts
+++ b/src/helpers/collectionOptions.ts
@@ -1,0 +1,65 @@
+const COLLECTION_TAG_REGEX = /#collection\b/i;
+const TOP_TAG_REGEX = /#top:(\d+)-(\d+)-(\d+)/i;
+
+export interface TopPreset {
+  id: string;
+  label: string;
+  tiers: TopTiers;
+}
+
+export type TopTiers = [number, number, number];
+
+export const TOP_PRESETS: TopPreset[] = [
+  { id: "top20", label: "Top 20", tiers: [5, 10, 5] },
+  { id: "top50", label: "Top 50", tiers: [10, 20, 20] },
+  { id: "top100", label: "Top 100", tiers: [10, 30, 60] },
+];
+
+/**
+ * Builds the final description sent to the Spotify API from the user's own
+ * text and the current collection options (tags are always prepended).
+ */
+export function buildCollectionDescription(
+  cleanText: string,
+  isCollection: boolean,
+  topTiers: null | TopTiers,
+): string {
+  const tags = [isCollection ? "#Collection" : "", topTiers ? `#Top:${topTiers.join("-")}` : ""]
+    .filter(Boolean)
+    .join(" ");
+  return [tags, cleanText].filter(Boolean).join(" ").trim();
+}
+
+/**
+ * Tier index (0 = biggest) for a given 0-based rank position. Any position
+ * beyond the last tier's boundary stays in the last tier.
+ */
+export function getTierForIndex(index: number, tiers: TopTiers): 0 | 1 | 2 {
+  if (index < tiers[0]) return 0;
+  if (index < tiers[0] + tiers[1]) return 1;
+  return 2;
+}
+
+export function getTierLabel(tierIndex: 0 | 1 | 2, tiers: TopTiers): string {
+  if (tierIndex === 0) return `Top ${tiers[0]}`;
+  if (tierIndex === 1) return `${tiers[0] + 1}–${tiers[0] + tiers[1]}`;
+  return `${tiers[0] + tiers[1] + 1}+`;
+}
+
+export function isDescriptionCollection(description: string): boolean {
+  return COLLECTION_TAG_REGEX.test(description);
+}
+
+export function parseTopTiers(description: string): null | TopTiers {
+  const match = description.match(TOP_TAG_REGEX);
+  if (!match) return null;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+/**
+ * Removes the #Collection and #Top:x-y-z tags from a description, leaving
+ * only the user's own text (used to populate/display the edit textarea).
+ */
+export function stripCollectionTags(description: string): string {
+  return description.replace(TOP_TAG_REGEX, "").replace(COLLECTION_TAG_REGEX, "").trim();
+}

--- a/src/helpers/collectionOptions.ts
+++ b/src/helpers/collectionOptions.ts
@@ -25,10 +25,10 @@ export type CollectionRankingMode
 
 export interface TierDefinition {
   label: string;
-  size: null | number;
+  size: number;
 }
 
-/** Ordered list of tiers; only the last entry may have `size: null` (open-ended, takes the remainder). */
+/** Ordered list of tiers, each with an explicit, drag-managed size. */
 export type TierList = TierDefinition[];
 
 export interface TopPreset {
@@ -61,6 +61,11 @@ export function buildCollectionDescription(
   return [tags, cleanText].filter(Boolean).join(" ").trim();
 }
 
+/** Builds an id → position lookup for O(1) rank lookups instead of repeated `findIndex` scans. */
+export function buildRankIndex<T extends { id: string }>(items: T[]): Map<string, number> {
+  return new Map(items.map((item, index) => [item.id, index]));
+}
+
 /**
  * Encodes a tier list into the compact `#Tier:label=size,label=size,...` tag.
  * Every category has an explicit, drag-managed size — none of them is an
@@ -68,7 +73,7 @@ export function buildCollectionDescription(
  * bucket that newly added albums land in (see UNSORTED_TIER_LABEL).
  */
 export function buildTierTag(tiers: TierList): string {
-  const body = tiers.map((tier) => `${sanitizeTierLabel(tier.label)}=${tier.size ?? 0}`).join(",");
+  const body = tiers.map((tier) => `${sanitizeTierLabel(tier.label)}=${tier.size}`).join(",");
   return `#Tier:${body}`;
 }
 
@@ -96,20 +101,26 @@ export function getTierColor(index: number, total: number): string {
   return `hsl(${hue} 70% 40% / 50%)`;
 }
 
-/**
- * Tier index (0 = biggest) for a given 0-based rank position in "Top" mode.
- * Any position beyond the last tier's boundary stays in the last tier.
- */
-export function getTierForIndex(index: number, tiers: TopTiers): 0 | 1 | 2 {
-  if (index < tiers[0]) return 0;
-  if (index < tiers[0] + tiers[1]) return 1;
-  return 2;
-}
-
 export function getTierLabel(tierIndex: 0 | 1 | 2, tiers: TopTiers): string {
   if (tierIndex === 0) return `Top ${tiers[0]}`;
   if (tierIndex === 1) return `${tiers[0] + 1}–${tiers[0] + tiers[1]}`;
   return `${tiers[0] + tiers[1] + 1}+`;
+}
+
+/**
+ * Splits items into one bucket per tier (by stored size) plus a trailing
+ * "Unsorted" bucket (whatever's left over). Shared by the editable and
+ * read-only collection pages so the grouping math only lives in one place.
+ */
+export function groupByTierList<T>(items: T[], tierList: TierList): T[][] {
+  let offset = 0;
+  const groups = tierList.map((tier) => {
+    const group = items.slice(offset, offset + tier.size);
+    offset += tier.size;
+    return group;
+  });
+  groups.push(items.slice(offset));
+  return groups;
 }
 
 export function isDescriptionCollection(description: string): boolean {
@@ -138,8 +149,10 @@ export function parseTierList(description: string): null | TierList {
     .map((entry) => {
       const [label, sizeRaw] = entry.split("=");
       if (!label || !sizeRaw) return null;
-      const size = sizeRaw === "*" ? null : Number(sizeRaw);
-      if (size !== null && !Number.isFinite(size)) return null;
+      // "*" is a legacy sentinel from before the Unsorted bucket existed, when the
+      // last tier absorbed the remainder itself; treat it as empty (0) on read.
+      const size = sizeRaw === "*" ? 0 : Number(sizeRaw);
+      if (!Number.isFinite(size)) return null;
       return { label: decodeHtmlEntities(label), size };
     })
     .filter((tier): tier is TierDefinition => tier !== null);
@@ -164,6 +177,12 @@ export function remainingDescriptionBudget(description: string): number {
  */
 export function sanitizeTierLabel(label: string): string {
   return label.replace(/[,=\s]+/g, "_").replace(/^_+|_+$/g, "");
+}
+
+/** Splits items into the 3 fixed "Top" buckets (big / medium / rest) by count. */
+export function splitTopTiers<T>(items: T[], tiers: TopTiers): [T[], T[], T[]] {
+  const [big, medium] = tiers;
+  return [items.slice(0, big), items.slice(big, big + medium), items.slice(big + medium)];
 }
 
 /**

--- a/src/helpers/collectionOptions.ts
+++ b/src/helpers/collectionOptions.ts
@@ -174,9 +174,11 @@ export function remainingDescriptionBudget(description: string): number {
  * Strips characters that would break the `#Tier:` tag encoding out of a
  * user-entered label. The tag body cannot contain whitespace (see
  * TIER_TAG_REGEX), so spaces become underscores rather than being dropped.
+ * `#` is stripped too so a label can't accidentally read back as a new
+ * `#Top:`/`#Tier:`/`#Collection` tag when the description is re-parsed.
  */
 export function sanitizeTierLabel(label: string): string {
-  return label.replace(/[,=\s]+/g, "_").replace(/^_+|_+$/g, "");
+  return label.replace(/[,=#\s]+/g, "_").replace(/^_+|_+$/g, "");
 }
 
 /** Splits items into the 3 fixed "Top" buckets (big / medium / rest) by count. */

--- a/src/helpers/collectionOptions.ts
+++ b/src/helpers/collectionOptions.ts
@@ -101,7 +101,7 @@ export function getTierColor(index: number, total: number): string {
   return `hsl(${hue} 70% 40% / 50%)`;
 }
 
-export function getTierLabel(tierIndex: 0 | 1 | 2, tiers: TopTiers): string {
+export function getTierLabel(tierIndex: number, tiers: TopTiers): string {
   if (tierIndex === 0) return `Top ${tiers[0]}`;
   if (tierIndex === 1) return `${tiers[0] + 1}–${tiers[0] + tiers[1]}`;
   return `${tiers[0] + tiers[1] + 1}+`;

--- a/src/helpers/collectionOptions.ts
+++ b/src/helpers/collectionOptions.ts
@@ -1,5 +1,28 @@
 const COLLECTION_TAG_REGEX = /#collection\b/i;
 const TOP_TAG_REGEX = /#top:(\d+)-(\d+)-(\d+)/i;
+const TIER_TAG_REGEX = /#tier:(\S+)/i;
+
+export const MAX_DESCRIPTION_LENGTH = 300;
+
+/**
+ * A collection's ranking is either off, the fixed 3-tier "Top" mode (counts
+ * only, auto-generated labels), or the free-form "Tier list" mode (custom
+ * labels, arbitrary category count). The two modes are mutually exclusive —
+ * a collection is never both at once, and one is never silently converted
+ * into the other.
+ */
+export type CollectionRankingMode
+  = | { tiers: TierList; type: "tierlist" }
+    | { tiers: TopTiers; type: "top" }
+    | { type: "off" };
+
+export interface TierDefinition {
+  label: string;
+  size: null | number;
+}
+
+/** Ordered list of tiers; only the last entry may have `size: null` (open-ended, takes the remainder). */
+export type TierList = TierDefinition[];
 
 export interface TopPreset {
   id: string;
@@ -17,22 +40,58 @@ export const TOP_PRESETS: TopPreset[] = [
 
 /**
  * Builds the final description sent to the Spotify API from the user's own
- * text and the current collection options (tags are always prepended).
+ * text and the current collection ranking mode (tags are always prepended).
  */
 export function buildCollectionDescription(
   cleanText: string,
   isCollection: boolean,
-  topTiers: null | TopTiers,
+  mode: CollectionRankingMode,
 ): string {
-  const tags = [isCollection ? "#Collection" : "", topTiers ? `#Top:${topTiers.join("-")}` : ""]
-    .filter(Boolean)
-    .join(" ");
+  let modeTag = "";
+  if (mode.type === "top") modeTag = `#Top:${mode.tiers.join("-")}`;
+  else if (mode.type === "tierlist") modeTag = buildTierTag(mode.tiers);
+  const tags = [isCollection ? "#Collection" : "", modeTag].filter(Boolean).join(" ");
   return [tags, cleanText].filter(Boolean).join(" ").trim();
 }
 
 /**
- * Tier index (0 = biggest) for a given 0-based rank position. Any position
- * beyond the last tier's boundary stays in the last tier.
+ * Encodes a tier list into the compact `#Tier:label=size,label=size,...` tag.
+ * The last tier's size is always encoded as `*` (open-ended, takes the rest).
+ */
+export function buildTierTag(tiers: TierList): string {
+  const body = tiers
+    .map((tier, index) => `${sanitizeTierLabel(tier.label)}=${index === tiers.length - 1 ? "*" : tier.size}`)
+    .join(",");
+  return `#Tier:${body}`;
+}
+
+/**
+ * Decodes HTML entities Spotify sometimes encodes into description text
+ * (e.g. apostrophes come back as `&#x27;`), so labels display as typed.
+ */
+export function decodeHtmlEntities(text: string): string {
+  const el = document.createElement("textarea");
+  el.innerHTML = text;
+  return el.value;
+}
+
+/** Converts a stored label's underscores back to spaces for display. */
+export function displayTierLabel(label: string): string {
+  return label.replace(/_/g, " ");
+}
+
+/**
+ * Default color for a Tier list category, from red (index 0, best) to green
+ * (last index, worst), interpolated through the hue wheel.
+ */
+export function getTierColor(index: number, total: number): string {
+  const hue = (index / Math.max(total - 1, 1)) * 120;
+  return `hsl(${hue} 70% 40%)`;
+}
+
+/**
+ * Tier index (0 = biggest) for a given 0-based rank position in "Top" mode.
+ * Any position beyond the last tier's boundary stays in the last tier.
  */
 export function getTierForIndex(index: number, tiers: TopTiers): 0 | 1 | 2 {
   if (index < tiers[0]) return 0;
@@ -50,16 +109,60 @@ export function isDescriptionCollection(description: string): boolean {
   return COLLECTION_TAG_REGEX.test(description);
 }
 
+/**
+ * Parses the ranking mode from a description: `#Top:` and `#Tier:` are
+ * checked independently (never converted into one another) and are expected
+ * to be mutually exclusive since only one is ever written at save time.
+ */
+export function parseCollectionRankingMode(description: string): CollectionRankingMode {
+  const tiers = parseTierList(description);
+  if (tiers) return { tiers, type: "tierlist" };
+  const topTiers = parseTopTiers(description);
+  if (topTiers) return { tiers: topTiers, type: "top" };
+  return { type: "off" };
+}
+
+/** Parses the `#Tier:label=size,...` tag only — no fallback to `#Top:`. */
+export function parseTierList(description: string): null | TierList {
+  const tierMatch = description.match(TIER_TAG_REGEX);
+  if (!tierMatch) return null;
+  const tiers = tierMatch[1]
+    .split(",")
+    .map((entry) => {
+      const [label, sizeRaw] = entry.split("=");
+      if (!label || !sizeRaw) return null;
+      const size = sizeRaw === "*" ? null : Number(sizeRaw);
+      if (size !== null && !Number.isFinite(size)) return null;
+      return { label: decodeHtmlEntities(label), size };
+    })
+    .filter((tier): tier is TierDefinition => tier !== null);
+  return tiers.length ? tiers : null;
+}
+
 export function parseTopTiers(description: string): null | TopTiers {
   const match = description.match(TOP_TAG_REGEX);
   if (!match) return null;
   return [Number(match[1]), Number(match[2]), Number(match[3])];
 }
 
+/** Remaining characters before hitting Spotify's description length limit. */
+export function remainingDescriptionBudget(description: string): number {
+  return MAX_DESCRIPTION_LENGTH - description.length;
+}
+
 /**
- * Removes the #Collection and #Top:x-y-z tags from a description, leaving
- * only the user's own text (used to populate/display the edit textarea).
+ * Strips characters that would break the `#Tier:` tag encoding out of a
+ * user-entered label. The tag body cannot contain whitespace (see
+ * TIER_TAG_REGEX), so spaces become underscores rather than being dropped.
+ */
+export function sanitizeTierLabel(label: string): string {
+  return label.replace(/[,=\s]+/g, "_").replace(/^_+|_+$/g, "");
+}
+
+/**
+ * Removes the #Collection, #Top:x-y-z and #Tier:... tags from a description,
+ * leaving only the user's own text (used to populate/display the edit textarea).
  */
 export function stripCollectionTags(description: string): string {
-  return description.replace(TOP_TAG_REGEX, "").replace(COLLECTION_TAG_REGEX, "").trim();
+  return description.replace(TIER_TAG_REGEX, "").replace(TOP_TAG_REGEX, "").replace(COLLECTION_TAG_REGEX, "").trim();
 }

--- a/src/helpers/dragAutoScroll.ts
+++ b/src/helpers/dragAutoScroll.ts
@@ -1,0 +1,21 @@
+/**
+ * Scroll delta for a SortableJS `scrollFn` autoscroll handler: negative
+ * (scroll up) when the pointer is within `sensitivity` of the top edge,
+ * positive (scroll down) near the bottom edge, or null outside both zones —
+ * meaning the caller should return "continue" and let the default behavior
+ * apply. Speed ramps up linearly as the pointer gets closer to the edge.
+ */
+export function computeAutoScrollDelta(
+  distanceFromTop: number,
+  distanceFromBottom: number,
+  sensitivity: number,
+  maxSpeed: number,
+): null | number {
+  if (distanceFromTop >= 0 && distanceFromTop < sensitivity) {
+    return -Math.ceil(maxSpeed * (1 - distanceFromTop / sensitivity));
+  }
+  if (distanceFromBottom >= 0 && distanceFromBottom < sensitivity) {
+    return Math.ceil(maxSpeed * (1 - distanceFromBottom / sensitivity));
+  }
+  return null;
+}

--- a/src/helpers/isCollection.ts
+++ b/src/helpers/isCollection.ts
@@ -1,10 +1,21 @@
-import { SimplifiedPlaylist } from "@/@types/Playlist";
+import { Playlist, SimplifiedPlaylist } from "@/@types/Playlist";
+import { isDescriptionCollection } from "@/helpers/collectionOptions";
 
 /**
- * Returns true if the playlist is a Collection (i.e. its name contains "#collection").
+ * Returns true if the playlist is a Collection (i.e. its description contains "#collection").
  * Collections are the core Beardify feature that transforms playlists into album collections.
- * @param playlist - Spotify simplified playlist object
+ * @param playlist - Spotify (simplified or full) playlist object
  */
-export function isACollection(playlist: SimplifiedPlaylist): boolean {
-  return playlist.name.toLowerCase().includes("#collection");
+export function isACollection(playlist: Playlist | SimplifiedPlaylist): boolean {
+  return isDescriptionCollection(playlist.description);
+}
+
+/**
+ * Returns true if the playlist still uses the old naming convention
+ * (tag in the name) and hasn't been converted to the new description-based
+ * tag yet.
+ * @param playlist - Spotify (simplified or full) playlist object
+ */
+export function isLegacyCollectionName(playlist: Playlist | SimplifiedPlaylist): boolean {
+  return isDescriptionCollection(playlist.name) && !isACollection(playlist);
 }

--- a/src/views/playlist/CollectionPage.vue
+++ b/src/views/playlist/CollectionPage.vue
@@ -16,12 +16,7 @@
             <div class="tier-section">
               <template v-if="tier0.length">
                 <div class="tier-heading">{{ getTierLabel(0, topTiers) }}</div>
-                <VueDraggable
-                  v-model="tier0"
-                  v-bind="dragOptions"
-                  class="tier-grid tier-grid-0"
-                  @end="(event) => handleTierEnd(0, event)"
-                >
+                <VueDraggable v-model="tier0" v-bind="dragOptions" class="tier-grid tier-grid-0" @end="handleTierEnd">
                   <Album
                     v-for="item in tier0"
                     :key="item.id"
@@ -35,12 +30,7 @@
               </template>
               <template v-if="tier1.length">
                 <div class="tier-heading">{{ getTierLabel(1, topTiers) }}</div>
-                <VueDraggable
-                  v-model="tier1"
-                  v-bind="dragOptions"
-                  class="tier-grid tier-grid-1"
-                  @end="(event) => handleTierEnd(1, event)"
-                >
+                <VueDraggable v-model="tier1" v-bind="dragOptions" class="tier-grid tier-grid-1" @end="handleTierEnd">
                   <Album
                     v-for="item in tier1"
                     :key="item.id"
@@ -54,12 +44,7 @@
               </template>
               <template v-if="tier2.length">
                 <div class="tier-heading">{{ getTierLabel(2, topTiers) }}</div>
-                <VueDraggable
-                  v-model="tier2"
-                  v-bind="dragOptions"
-                  class="tier-grid tier-grid-2"
-                  @end="(event) => handleTierEnd(2, event)"
-                >
+                <VueDraggable v-model="tier2" v-bind="dragOptions" class="tier-grid tier-grid-2" @end="handleTierEnd">
                   <Album
                     v-for="item in tier2"
                     :key="item.id"
@@ -121,20 +106,62 @@ const albumListFiltered = computed<AlbumSimplified[]>(() =>
 
 const topTiers = computed<null | TopTiers>(() => parseTopTiers(playlistStore.playlist.description));
 
+const AUTO_SCROLL_SENSITIVITY = 150;
+const AUTO_SCROLL_MAX_SPEED = 100;
+
+function handleAutoScroll(
+  _offsetX: number,
+  _offsetY: number,
+  originalEvent: Event,
+  touchEvt: TouchEvent,
+  hoverTargetEl: HTMLElement,
+): "continue" | void {
+  const pointerEvent = touchEvt?.touches?.length ? touchEvt.touches[0] : (originalEvent as MouseEvent);
+  const rect = hoverTargetEl.getBoundingClientRect();
+  const distanceFromTop = pointerEvent.clientY - rect.top;
+  const distanceFromBottom = rect.bottom - pointerEvent.clientY;
+
+  if (distanceFromTop >= 0 && distanceFromTop < AUTO_SCROLL_SENSITIVITY) {
+    const ratio = 1 - distanceFromTop / AUTO_SCROLL_SENSITIVITY;
+    hoverTargetEl.scrollTop -= Math.ceil(AUTO_SCROLL_MAX_SPEED * ratio);
+    return;
+  }
+  if (distanceFromBottom >= 0 && distanceFromBottom < AUTO_SCROLL_SENSITIVITY) {
+    const ratio = 1 - distanceFromBottom / AUTO_SCROLL_SENSITIVITY;
+    hoverTargetEl.scrollTop += Math.ceil(AUTO_SCROLL_MAX_SPEED * ratio);
+    return;
+  }
+  return "continue";
+}
+
 const dragOptions = computed(() => ({
   animation: 150,
   delay: 200,
   disabled: playlistStore.playlist.owner.id !== authStore.me?.id,
   forceFallback: true,
-  scrollSensitivity: 100,
-  scrollSpeed: 15,
+  group: "collection-tiers",
+  scrollFn: handleAutoScroll,
+  scrollSensitivity: AUTO_SCROLL_SENSITIVITY,
+  scrollSpeed: AUTO_SCROLL_MAX_SPEED,
 }));
 
-function handleTierEnd(tierIndex: 0 | 1 | 2, event: { newIndex?: number; oldIndex?: number }): void {
-  if (event.oldIndex === undefined || event.newIndex === undefined) return;
-  const offset = tierOffset(tierIndex);
-  playlistStore.updateCollectionPosition(offset + event.oldIndex, offset + event.newIndex);
-  albumList.value = [...tier0.value, ...tier1.value, ...tier2.value];
+/**
+ * Finds the single item that moved between two otherwise-identical lists by
+ * locating the first index where they diverge and tracing that item's prior
+ * position via its id.
+ */
+function findMove(previous: AlbumSimplified[], next: AlbumSimplified[]): { newIndex: number; oldIndex: number } | null {
+  const newIndex = previous.findIndex((album, i) => album.id !== next[i]?.id);
+  if (newIndex === -1) return null;
+  const oldIndex = previous.findIndex((album) => album.id === next[newIndex].id);
+  return { newIndex, oldIndex };
+}
+
+function handleTierEnd(): void {
+  const nextOrder = [...tier0.value, ...tier1.value, ...tier2.value];
+  const move = findMove(albumList.value, nextOrder);
+  if (move) playlistStore.updateCollectionPosition(move.oldIndex, move.newIndex);
+  albumList.value = nextOrder;
 }
 
 function indexOfAlbum(id: string): number {
@@ -161,13 +188,6 @@ function syncTiers(): void {
   tier0.value = albumList.value.slice(0, big);
   tier1.value = albumList.value.slice(big, big + medium);
   tier2.value = albumList.value.slice(big + medium);
-}
-
-function tierOffset(tierIndex: 0 | 1 | 2): number {
-  if (!topTiers.value) return 0;
-  if (tierIndex === 0) return 0;
-  if (tierIndex === 1) return topTiers.value[0];
-  return topTiers.value[0] + topTiers.value[1];
 }
 
 watch([albumList, topTiers], syncTiers, { immediate: true });

--- a/src/views/playlist/CollectionPage.vue
+++ b/src/views/playlist/CollectionPage.vue
@@ -16,7 +16,12 @@
             <div class="tier-section">
               <template v-if="tier0.length">
                 <div class="tier-heading">{{ getTierLabel(0, topTiers) }}</div>
-                <VueDraggable v-model="tier0" v-bind="dragOptions" class="tier-grid tier-grid-0" @end="handleTierEnd">
+                <VueDraggable
+                  v-model="tier0"
+                  v-bind="dragOptions"
+                  class="tier-grid tier-grid-0"
+                  @end="handleTopTierEnd"
+                >
                   <Album
                     v-for="item in tier0"
                     :key="item.id"
@@ -30,7 +35,12 @@
               </template>
               <template v-if="tier1.length">
                 <div class="tier-heading">{{ getTierLabel(1, topTiers) }}</div>
-                <VueDraggable v-model="tier1" v-bind="dragOptions" class="tier-grid tier-grid-1" @end="handleTierEnd">
+                <VueDraggable
+                  v-model="tier1"
+                  v-bind="dragOptions"
+                  class="tier-grid tier-grid-1"
+                  @end="handleTopTierEnd"
+                >
                   <Album
                     v-for="item in tier1"
                     :key="item.id"
@@ -44,12 +54,44 @@
               </template>
               <template v-if="tier2.length">
                 <div class="tier-heading">{{ getTierLabel(2, topTiers) }}</div>
-                <VueDraggable v-model="tier2" v-bind="dragOptions" class="tier-grid tier-grid-2" @end="handleTierEnd">
+                <VueDraggable
+                  v-model="tier2"
+                  v-bind="dragOptions"
+                  class="tier-grid tier-grid-2"
+                  @end="handleTopTierEnd"
+                >
                   <Album
                     v-for="item in tier2"
                     :key="item.id"
                     :album="item"
                     :rank="rankOf(item.id)"
+                    can-delete
+                    can-save
+                    with-artists
+                  />
+                </VueDraggable>
+              </template>
+            </div>
+          </template>
+          <template v-else-if="tierList">
+            <div class="tier-section">
+              <template v-for="(tier, i) in tierList" :key="i">
+                <div
+                  class="tier-heading tier-heading-colored"
+                  :style="{ backgroundColor: getTierColor(i, tierList.length) }"
+                >
+                  {{ displayTierLabel(tier.label) }}
+                </div>
+                <VueDraggable
+                  v-model="tierGroups[i]"
+                  v-bind="dragOptions"
+                  class="tier-grid tier-grid-dynamic"
+                  @end="handleTierListEnd"
+                >
+                  <Album
+                    v-for="item in tierGroups[i]"
+                    :key="item.id"
+                    :album="item"
                     can-delete
                     can-save
                     with-artists
@@ -72,12 +114,24 @@ import { computed, onMounted, ref, watch } from "vue";
 import { VueDraggable } from "vue-draggable-plus";
 
 import { AlbumSimplified } from "@/@types/Album";
+import { NotificationType } from "@/@types/Notification";
+import { instance } from "@/api";
 import Album from "@/components/album/AlbumIndex.vue";
 import Header from "@/components/playlist/PlaylistHeader.vue";
 import Loader from "@/components/ui/LoadingDots.vue";
 import PageFit from "@/components/ui/PageFit.vue";
 import PageScroller from "@/components/ui/PageScroller.vue";
-import { getTierLabel, parseTopTiers, TopTiers } from "@/helpers/collectionOptions";
+import {
+  buildCollectionDescription,
+  displayTierLabel,
+  getTierColor,
+  getTierLabel,
+  parseCollectionRankingMode,
+  stripCollectionTags,
+  TierList,
+  TopTiers,
+} from "@/helpers/collectionOptions";
+import { notification } from "@/helpers/notifications";
 import { removeDuplicatesAlbums } from "@/helpers/removeDuplicate";
 import { useAuth } from "@/views/auth/AuthStore";
 import { usePlaylist } from "@/views/playlist/PlaylistStore";
@@ -90,6 +144,7 @@ const scrollerRef = ref<InstanceType<typeof PageScroller>>();
 const tier0 = ref<AlbumSimplified[]>([]);
 const tier1 = ref<AlbumSimplified[]>([]);
 const tier2 = ref<AlbumSimplified[]>([]);
+const tierGroups = ref<AlbumSimplified[][]>([]);
 const syncAlbumList = (): void => {
   albumList.value = removeDuplicatesAlbums(playlistStore.tracks.map((a) => a.item.album));
 };
@@ -104,7 +159,13 @@ const albumListFiltered = computed<AlbumSimplified[]>(() =>
   }),
 );
 
-const topTiers = computed<null | TopTiers>(() => parseTopTiers(playlistStore.playlist.description));
+const rankingMode = computed(() => parseCollectionRankingMode(playlistStore.playlist.description));
+const topTiers = computed<null | TopTiers>(() =>
+  rankingMode.value.type === "top" ? rankingMode.value.tiers : null,
+);
+const tierList = computed<null | TierList>(() =>
+  rankingMode.value.type === "tierlist" ? rankingMode.value.tiers : null,
+);
 
 const AUTO_SCROLL_SENSITIVITY = 150;
 const AUTO_SCROLL_MAX_SPEED = 100;
@@ -145,6 +206,12 @@ const dragOptions = computed(() => ({
   scrollSpeed: AUTO_SCROLL_MAX_SPEED,
 }));
 
+function applyReorder(nextOrder: AlbumSimplified[]): void {
+  const move = findMove(albumList.value, nextOrder);
+  if (move) playlistStore.updateCollectionPosition(move.oldIndex, move.newIndex);
+  albumList.value = nextOrder;
+}
+
 /**
  * Finds the single item that moved between two otherwise-identical lists by
  * locating the first index where they diverge and tracing that item's prior
@@ -157,11 +224,13 @@ function findMove(previous: AlbumSimplified[], next: AlbumSimplified[]): { newIn
   return { newIndex, oldIndex };
 }
 
-function handleTierEnd(): void {
-  const nextOrder = [...tier0.value, ...tier1.value, ...tier2.value];
-  const move = findMove(albumList.value, nextOrder);
-  if (move) playlistStore.updateCollectionPosition(move.oldIndex, move.newIndex);
-  albumList.value = nextOrder;
+function handleTierListEnd(): void {
+  applyReorder(tierGroups.value.flat());
+  syncTierSizesToDescription();
+}
+
+function handleTopTierEnd(): void {
+  applyReorder([...tier0.value, ...tier1.value, ...tier2.value]);
 }
 
 function indexOfAlbum(id: string): number {
@@ -177,7 +246,51 @@ function syncNewPositions(event: { newIndex?: number; oldIndex?: number }): void
   playlistStore.updateCollectionPosition(event.oldIndex, event.newIndex);
 }
 
-function syncTiers(): void {
+function syncTierGroups(): void {
+  const list = tierList.value;
+  if (!list) {
+    tierGroups.value = [];
+    return;
+  }
+  let offset = 0;
+  tierGroups.value = list.map((tier, index) => {
+    if (index === list.length - 1) return albumList.value.slice(offset);
+    const size = tier.size ?? 0;
+    const group = albumList.value.slice(offset, offset + size);
+    offset += size;
+    return group;
+  });
+}
+
+/**
+ * Tier sizes are counts, not membership: after a cross-tier drag the item
+ * counts per bucket have changed, so the stored `#Tier:` sizes must be
+ * updated to match — otherwise the next recompute re-slices the flat album
+ * order by the old (now stale) counts and snaps the dragged item back.
+ * Updates the description synchronously (optimistic) so the recompute
+ * triggered by the position change already sees the new sizes.
+ */
+function syncTierSizesToDescription(): void {
+  const list = tierList.value;
+  if (!list) return;
+  const updatedList: TierList = list.map((tier, index) =>
+    index === list.length - 1 ? tier : { ...tier, size: tierGroups.value[index]?.length ?? tier.size },
+  );
+  const freeText = stripCollectionTags(playlistStore.playlist.description);
+  const newDescription = buildCollectionDescription(freeText, true, { tiers: updatedList, type: "tierlist" });
+  if (newDescription === playlistStore.playlist.description) return;
+
+  const previousDescription = playlistStore.playlist.description;
+  playlistStore.playlist.description = newDescription;
+  instance()
+    .put(`playlists/${playlistStore.playlist.id}`, { description: newDescription })
+    .catch(() => {
+      playlistStore.playlist.description = previousDescription;
+      notification({ msg: "Unable to update the tier list. Please try again.", type: NotificationType.Error });
+    });
+}
+
+function syncTopTiers(): void {
   if (!topTiers.value) {
     tier0.value = [];
     tier1.value = [];
@@ -190,7 +303,8 @@ function syncTiers(): void {
   tier2.value = albumList.value.slice(big + medium);
 }
 
-watch([albumList, topTiers], syncTiers, { immediate: true });
+watch([albumList, topTiers], syncTopTiers, { immediate: true });
+watch([albumList, tierList], syncTierGroups, { immediate: true });
 
 watch(
   () => playlistStore.tracks,
@@ -308,6 +422,11 @@ playlistStore.clean().finally(() => {
   }
 }
 
+.tier-heading-colored {
+  color: #fff;
+  text-shadow: 0 0.1rem 0.2rem rgb(0 0 0 / 40%);
+}
+
 .tier-grid {
   display: grid;
   gap: 2rem;
@@ -327,5 +446,10 @@ playlistStore.clean().finally(() => {
 
 .tier-grid-2 {
   grid-template-columns: repeat(auto-fill, minmax(7rem, 1fr));
+}
+
+.tier-grid-dynamic {
+  grid-template-columns: repeat(auto-fill, minmax(10rem, 1fr));
+  min-height: 6rem;
 }
 </style>

--- a/src/views/playlist/CollectionPage.vue
+++ b/src/views/playlist/CollectionPage.vue
@@ -164,10 +164,13 @@ import PageFit from "@/components/ui/PageFit.vue";
 import PageScroller from "@/components/ui/PageScroller.vue";
 import {
   buildCollectionDescription,
+  buildRankIndex,
   displayTierLabel,
   getTierColor,
   getTierLabel,
+  groupByTierList,
   parseCollectionRankingMode,
+  splitTopTiers,
   stripCollectionTags,
   TierList,
   TopTiers,
@@ -202,6 +205,7 @@ const albumListFiltered = computed<AlbumSimplified[]>(() =>
   }),
 );
 
+const rankIndex = computed(() => buildRankIndex(albumList.value));
 const rankingMode = computed(() => parseCollectionRankingMode(playlistStore.playlist.description));
 const topTiers = computed<null | TopTiers>(() =>
   rankingMode.value.type === "top" ? rankingMode.value.tiers : null,
@@ -276,12 +280,8 @@ function handleTopTierEnd(): void {
   applyReorder([...tier0.value, ...tier1.value, ...tier2.value]);
 }
 
-function indexOfAlbum(id: string): number {
-  return albumList.value.findIndex((album) => album.id === id);
-}
-
 function rankOf(id: string): number {
-  return indexOfAlbum(id) + 1;
+  return (rankIndex.value.get(id) ?? -1) + 1;
 }
 
 /**
@@ -301,7 +301,7 @@ function shrinkTiersForRemovedAlbums(list: TierList, removedIds: string[]): null
     matched = true;
   });
   if (!matched) return null;
-  return list.map((tier, index) => ({ ...tier, size: Math.max((tier.size ?? 0) - decrements[index], 0) }));
+  return list.map((tier, index) => ({ ...tier, size: Math.max(tier.size - decrements[index], 0) }));
 }
 
 function syncNewPositions(event: { newIndex?: number; oldIndex?: number }): void {
@@ -341,15 +341,7 @@ function syncTierGroups(): void {
   }
 
   previousTierAlbumList = albumList.value;
-  let offset = 0;
-  const groups = list.map((tier) => {
-    const size = tier.size ?? 0;
-    const group = albumList.value.slice(offset, offset + size);
-    offset += size;
-    return group;
-  });
-  groups.push(albumList.value.slice(offset));
-  tierGroups.value = groups;
+  tierGroups.value = groupByTierList(albumList.value, list);
 }
 
 /**
@@ -375,10 +367,7 @@ function syncTopTiers(): void {
     tier2.value = [];
     return;
   }
-  const [big, medium] = topTiers.value;
-  tier0.value = albumList.value.slice(0, big);
-  tier1.value = albumList.value.slice(big, big + medium);
-  tier2.value = albumList.value.slice(big + medium);
+  [tier0.value, tier1.value, tier2.value] = splitTopTiers(albumList.value, topTiers.value);
 }
 
 /** Writes an updated tier list to the description (optimistic, background PUT, rolls back on failure). */

--- a/src/views/playlist/CollectionPage.vue
+++ b/src/views/playlist/CollectionPage.vue
@@ -19,7 +19,17 @@
               class="album-list"
               @end="syncNewPositions"
             >
-              <Album v-for="item in albumList" :key="item.id" :album="item" can-delete can-save with-artists />
+              <Album
+                v-for="item in albumList"
+                :key="item.id"
+                :album="item"
+                :class="topTiers ? tierClassFor(item.id) : undefined"
+                :data-tier-label="topTiers && isTierStart(item.id) ? tierLabelFor(item.id) : undefined"
+                :rank="topTiers ? rankOf(item.id) : undefined"
+                can-delete
+                can-save
+                with-artists
+              />
             </VueDraggable>
           </template>
           <div v-else class="album-list">
@@ -27,6 +37,9 @@
               v-for="item in albumListFiltered"
               :key="item.id"
               :album="item"
+              :class="topTiers ? tierClassFor(item.id) : undefined"
+              :data-tier-label="topTiers && isTierStart(item.id) ? tierLabelFor(item.id) : undefined"
+              :rank="topTiers ? rankOf(item.id) : undefined"
               can-delete
               can-save
               with-artists
@@ -48,6 +61,7 @@ import Header from "@/components/playlist/PlaylistHeader.vue";
 import Loader from "@/components/ui/LoadingDots.vue";
 import PageFit from "@/components/ui/PageFit.vue";
 import PageScroller from "@/components/ui/PageScroller.vue";
+import { getTierForIndex, getTierLabel, parseTopTiers, TopTiers } from "@/helpers/collectionOptions";
 import { removeDuplicatesAlbums } from "@/helpers/removeDuplicate";
 import { useAuth } from "@/views/auth/AuthStore";
 import { usePlaylist } from "@/views/playlist/PlaylistStore";
@@ -71,9 +85,41 @@ const albumListFiltered = computed<AlbumSimplified[]>(() =>
   }),
 );
 
+const topTiers = computed<null | TopTiers>(() => parseTopTiers(playlistStore.playlist.description));
+
+function indexOfAlbum(id: string): number {
+  return albumList.value.findIndex((album) => album.id === id);
+}
+
+function isTierStart(id: string): boolean {
+  if (!topTiers.value) return false;
+  const index = indexOfAlbum(id);
+  if (index === 0) return true;
+  return getTierForIndex(index, topTiers.value) !== getTierForIndex(index - 1, topTiers.value);
+}
+
+function rankOf(id: string): number {
+  return indexOfAlbum(id) + 1;
+}
+
 function syncNewPositions(event: { newIndex?: number; oldIndex?: number }): void {
   if (event.oldIndex === undefined || event.newIndex === undefined) return;
   playlistStore.updateCollectionPosition(event.oldIndex, event.newIndex);
+}
+
+function tierClassFor(id: string): string {
+  const tier = tierOf(id);
+  return tier === null ? "" : `tier-${tier}`;
+}
+
+function tierLabelFor(id: string): string {
+  const tier = tierOf(id);
+  return tier === null || !topTiers.value ? "" : getTierLabel(tier, topTiers.value);
+}
+
+function tierOf(id: string): 0 | 1 | 2 | null {
+  if (!topTiers.value) return null;
+  return getTierForIndex(indexOfAlbum(id), topTiers.value);
 }
 
 watch(
@@ -94,6 +140,7 @@ playlistStore.clean().finally(() => {
 
 <style lang="scss" scoped>
 @use "@/assets/scss/colors" as colors;
+@use "@/assets/scss/mixins" as *;
 @use "@/assets/scss/responsive" as responsive;
 
 .collection {
@@ -110,6 +157,7 @@ playlistStore.clean().finally(() => {
 
   display: grid;
   gap: 2rem;
+  grid-auto-flow: dense;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   padding: 2rem 5rem;
   padding-left: $padd;
@@ -162,5 +210,30 @@ playlistStore.clean().finally(() => {
 .loader {
   display: grid;
   place-content: center;
+}
+
+/* stylelint-disable-next-line selector-pseudo-class-no-unknown */
+:deep(.tier-0) {
+  grid-column: span 2;
+  grid-row: span 2;
+}
+
+/* stylelint-disable-next-line selector-pseudo-class-no-unknown */
+:deep(.tier-2) {
+  transform: scale(0.85);
+  transform-origin: top left;
+}
+
+/* stylelint-disable-next-line selector-pseudo-class-no-unknown */
+:deep(.tier-start)::before {
+  content: attr(data-tier-label);
+  display: block;
+
+  @include font-bold;
+
+  font-size: var(--font-size-sm);
+  opacity: 0.5;
+  position: absolute;
+  top: -1.8rem;
 }
 </style>

--- a/src/views/playlist/CollectionPage.vue
+++ b/src/views/playlist/CollectionPage.vue
@@ -19,7 +19,7 @@
                 <VueDraggable
                   v-model="tier0"
                   v-bind="dragOptions"
-                  class="tier-grid tier-grid-0"
+                  :class="['tier-grid', 'tier-grid-0', { 'draggable-grid': !dragOptions.disabled }]"
                   @end="handleTopTierEnd"
                 >
                   <Album
@@ -38,7 +38,7 @@
                 <VueDraggable
                   v-model="tier1"
                   v-bind="dragOptions"
-                  class="tier-grid tier-grid-1"
+                  :class="['tier-grid', 'tier-grid-1', { 'draggable-grid': !dragOptions.disabled }]"
                   @end="handleTopTierEnd"
                 >
                   <Album
@@ -57,7 +57,7 @@
                 <VueDraggable
                   v-model="tier2"
                   v-bind="dragOptions"
-                  class="tier-grid tier-grid-2"
+                  :class="['tier-grid', 'tier-grid-2', { 'draggable-grid': !dragOptions.disabled }]"
                   @end="handleTopTierEnd"
                 >
                   <Album
@@ -76,20 +76,54 @@
           <template v-else-if="tierList">
             <div class="tier-section">
               <template v-for="(tier, i) in tierList" :key="i">
+                <div class="tier-row" :class="{ 'tier-row-side': configStore.tierListSideLabels }">
+                  <div
+                    class="tier-heading tier-heading-colored"
+                    :class="{ 'tier-heading-side': configStore.tierListSideLabels }"
+                    :style="{ backgroundColor: getTierColor(i, tierList.length) }"
+                  >
+                    {{ displayTierLabel(tier.label) }}
+                  </div>
+                  <VueDraggable
+                    v-model="tierGroups[i]"
+                    v-bind="dragOptions"
+                    class="tier-grid"
+                    :class="[
+                      configStore.tierListSideLabels ? 'tier-grid-side' : 'tier-grid-dynamic',
+                      { 'draggable-grid': !dragOptions.disabled },
+                    ]"
+                    @end="handleTierListEnd"
+                  >
+                    <Album
+                      v-for="item in tierGroups[i]"
+                      :key="item.id"
+                      :album="item"
+                      can-delete
+                      can-save
+                      with-artists
+                    />
+                  </VueDraggable>
+                </div>
+              </template>
+              <div class="tier-row" :class="{ 'tier-row-side': configStore.tierListSideLabels }">
                 <div
-                  class="tier-heading tier-heading-colored"
-                  :style="{ backgroundColor: getTierColor(i, tierList.length) }"
+                  class="tier-heading tier-heading-unsorted"
+                  :class="{ 'tier-heading-side': configStore.tierListSideLabels }"
                 >
-                  {{ displayTierLabel(tier.label) }}
+                  {{ UNSORTED_TIER_LABEL }}
                 </div>
                 <VueDraggable
-                  v-model="tierGroups[i]"
+                  v-model="tierGroups[tierList.length]"
                   v-bind="dragOptions"
-                  class="tier-grid tier-grid-dynamic"
+                  class="tier-grid"
+                  :class="[
+                    configStore.tierListSideLabels ? 'tier-grid-side' : 'tier-grid-dynamic',
+                    { 'draggable-grid': !dragOptions.disabled },
+                  ]"
                   @end="handleTierListEnd"
                 >
                   <Album
-                    v-for="item in tierGroups[i]"
+                    v-for="item in tierGroups[tierList.length]"
                     :key="item.id"
                     :album="item"
                     can-delete
@@ -97,10 +131,16 @@
                     with-artists
                   />
                 </VueDraggable>
-              </template>
+              </div>
             </div>
           </template>
-          <VueDraggable v-else v-model="albumList" v-bind="dragOptions" class="album-list" @end="syncNewPositions">
+          <VueDraggable
+            v-else
+            v-model="albumList"
+            v-bind="dragOptions"
+            :class="['album-list', { 'draggable-grid': !dragOptions.disabled }]"
+            @end="syncNewPositions"
+          >
             <Album v-for="item in albumList" :key="item.id" :album="item" can-delete can-save with-artists />
           </VueDraggable>
         </div>
@@ -117,6 +157,7 @@ import { AlbumSimplified } from "@/@types/Album";
 import { NotificationType } from "@/@types/Notification";
 import { instance } from "@/api";
 import Album from "@/components/album/AlbumIndex.vue";
+import { useConfig } from "@/components/config/ConfigStore";
 import Header from "@/components/playlist/PlaylistHeader.vue";
 import Loader from "@/components/ui/LoadingDots.vue";
 import PageFit from "@/components/ui/PageFit.vue";
@@ -130,6 +171,7 @@ import {
   stripCollectionTags,
   TierList,
   TopTiers,
+  UNSORTED_TIER_LABEL,
 } from "@/helpers/collectionOptions";
 import { notification } from "@/helpers/notifications";
 import { removeDuplicatesAlbums } from "@/helpers/removeDuplicate";
@@ -137,6 +179,7 @@ import { useAuth } from "@/views/auth/AuthStore";
 import { usePlaylist } from "@/views/playlist/PlaylistStore";
 
 const props = defineProps<{ id: string }>();
+const configStore = useConfig();
 const playlistStore = usePlaylist();
 const albumList = ref<AlbumSimplified[]>([]);
 const authStore = useAuth();
@@ -241,25 +284,72 @@ function rankOf(id: string): number {
   return indexOfAlbum(id) + 1;
 }
 
+/**
+ * Given the tiers a set of now-deleted albums used to belong to (looked up
+ * from the last known grouping), decrements each affected tier's stored
+ * size by how many of its items were removed. The Unsorted bucket (index
+ * `list.length` in tierGroups, one past the stored tiers) never needs
+ * shrinking — it always absorbs whatever remains.
+ */
+function shrinkTiersForRemovedAlbums(list: TierList, removedIds: string[]): null | TierList {
+  const decrements = new Array<number>(list.length).fill(0);
+  let matched = false;
+  removedIds.forEach((id) => {
+    const tierIndex = tierGroups.value.findIndex((group) => group.some((album) => album.id === id));
+    if (tierIndex === -1 || tierIndex >= list.length) return;
+    decrements[tierIndex]++;
+    matched = true;
+  });
+  if (!matched) return null;
+  return list.map((tier, index) => ({ ...tier, size: Math.max((tier.size ?? 0) - decrements[index], 0) }));
+}
+
 function syncNewPositions(event: { newIndex?: number; oldIndex?: number }): void {
   if (event.oldIndex === undefined || event.newIndex === undefined) return;
   playlistStore.updateCollectionPosition(event.oldIndex, event.newIndex);
 }
 
+/**
+ * Tier membership is derived purely from position + stored sizes, so any
+ * external change to albumList (drag, but also deletion) that isn't
+ * reflected in the stored sizes causes the fixed-size recompute to pull an
+ * item up from the next tier to fill the gap. Deletions don't go through
+ * handleTierListEnd (they're triggered from the Album component itself), so
+ * this watcher detects a shrunk albumList, finds which tier the removed
+ * album belonged to (from the last known grouping), and shrinks that tier's
+ * stored size to match before the normal slice-based recompute runs.
+ */
+let previousTierAlbumList: AlbumSimplified[] = [];
+
 function syncTierGroups(): void {
   const list = tierList.value;
   if (!list) {
     tierGroups.value = [];
+    previousTierAlbumList = [];
     return;
   }
+
+  if (albumList.value.length < previousTierAlbumList.length) {
+    const remainingIds = new Set(albumList.value.map((album) => album.id));
+    const removedIds = previousTierAlbumList.filter((album) => !remainingIds.has(album.id)).map((album) => album.id);
+    const adjustedList = shrinkTiersForRemovedAlbums(list, removedIds);
+    if (adjustedList) {
+      previousTierAlbumList = albumList.value;
+      writeTierListDescription(adjustedList);
+      return;
+    }
+  }
+
+  previousTierAlbumList = albumList.value;
   let offset = 0;
-  tierGroups.value = list.map((tier, index) => {
-    if (index === list.length - 1) return albumList.value.slice(offset);
+  const groups = list.map((tier) => {
     const size = tier.size ?? 0;
     const group = albumList.value.slice(offset, offset + size);
     offset += size;
     return group;
   });
+  groups.push(albumList.value.slice(offset));
+  tierGroups.value = groups;
 }
 
 /**
@@ -267,27 +357,15 @@ function syncTierGroups(): void {
  * counts per bucket have changed, so the stored `#Tier:` sizes must be
  * updated to match — otherwise the next recompute re-slices the flat album
  * order by the old (now stale) counts and snaps the dragged item back.
- * Updates the description synchronously (optimistic) so the recompute
- * triggered by the position change already sees the new sizes.
  */
 function syncTierSizesToDescription(): void {
   const list = tierList.value;
   if (!list) return;
-  const updatedList: TierList = list.map((tier, index) =>
-    index === list.length - 1 ? tier : { ...tier, size: tierGroups.value[index]?.length ?? tier.size },
-  );
-  const freeText = stripCollectionTags(playlistStore.playlist.description);
-  const newDescription = buildCollectionDescription(freeText, true, { tiers: updatedList, type: "tierlist" });
-  if (newDescription === playlistStore.playlist.description) return;
-
-  const previousDescription = playlistStore.playlist.description;
-  playlistStore.playlist.description = newDescription;
-  instance()
-    .put(`playlists/${playlistStore.playlist.id}`, { description: newDescription })
-    .catch(() => {
-      playlistStore.playlist.description = previousDescription;
-      notification({ msg: "Unable to update the tier list. Please try again.", type: NotificationType.Error });
-    });
+  const updatedList: TierList = list.map((tier, index) => ({
+    ...tier,
+    size: tierGroups.value[index]?.length ?? tier.size,
+  }));
+  writeTierListDescription(updatedList);
 }
 
 function syncTopTiers(): void {
@@ -301,6 +379,22 @@ function syncTopTiers(): void {
   tier0.value = albumList.value.slice(0, big);
   tier1.value = albumList.value.slice(big, big + medium);
   tier2.value = albumList.value.slice(big + medium);
+}
+
+/** Writes an updated tier list to the description (optimistic, background PUT, rolls back on failure). */
+function writeTierListDescription(updatedList: TierList): void {
+  const freeText = stripCollectionTags(playlistStore.playlist.description);
+  const newDescription = buildCollectionDescription(freeText, true, { tiers: updatedList, type: "tierlist" });
+  if (newDescription === playlistStore.playlist.description) return;
+
+  const previousDescription = playlistStore.playlist.description;
+  playlistStore.playlist.description = newDescription;
+  instance()
+    .put(`playlists/${playlistStore.playlist.id}`, { description: newDescription })
+    .catch(() => {
+      playlistStore.playlist.description = previousDescription;
+      notification({ msg: "Unable to update the tier list. Please try again.", type: NotificationType.Error });
+    });
 }
 
 watch([albumList, topTiers], syncTopTiers, { immediate: true });
@@ -407,15 +501,25 @@ playlistStore.clean().finally(() => {
   }
 }
 
+.tier-row {
+  display: contents;
+}
+
+.tier-row-side {
+  align-items: stretch;
+  display: flex;
+  margin-bottom: 1.5rem;
+}
+
 .tier-heading {
   background-color: var(--bg-color);
   border-radius: 0.4rem;
-
-  @include font-bold;
-
   font-size: var(--font-size-lg);
+  line-break: anywhere;
   margin: 2rem 0 1rem;
   padding: 0.7rem 1.2rem;
+
+  @include font-bold;
 
   &:first-child {
     margin-top: 0;
@@ -425,6 +529,29 @@ playlistStore.clean().finally(() => {
 .tier-heading-colored {
   color: #fff;
   text-shadow: 0 0.1rem 0.2rem rgb(0 0 0 / 40%);
+}
+
+.tier-heading-unsorted {
+  background-color: transparent;
+  border: 0.1rem dashed var(--bg-color-lighter);
+  color: var(--font-color-dark);
+  font-style: italic;
+  opacity: 0.7;
+}
+
+.tier-heading-side {
+  align-items: center;
+  border-radius: 0.4rem 0 0 0.4rem;
+  display: flex;
+  flex-shrink: 0;
+  justify-content: center;
+  margin: 0;
+  text-align: center;
+  width: 8rem;
+
+  @include responsive.mobile {
+    width: 5rem;
+  }
 }
 
 .tier-grid {
@@ -451,5 +578,36 @@ playlistStore.clean().finally(() => {
 .tier-grid-dynamic {
   grid-template-columns: repeat(auto-fill, minmax(10rem, 1fr));
   min-height: 6rem;
+}
+
+.tier-grid-side {
+  background-color: var(--bg-color);
+  border-radius: 0 0.4rem 0.4rem 0;
+  display: flex;
+  flex: 1;
+  flex-wrap: wrap;
+  min-height: 8rem;
+  padding: 1rem;
+
+  /* stylelint-disable-next-line selector-pseudo-class-no-unknown */
+  :deep(.album) {
+    width: 8rem;
+
+    @include responsive.mobile {
+      width: 6rem;
+    }
+  }
+}
+
+.draggable-grid {
+  /* stylelint-disable-next-line selector-pseudo-class-no-unknown */
+  :deep(.album) {
+    cursor: grab;
+  }
+
+  /* stylelint-disable-next-line selector-pseudo-class-no-unknown */
+  :deep(.sortable-chosen) {
+    cursor: grabbing;
+  }
 }
 </style>

--- a/src/views/playlist/CollectionPage.vue
+++ b/src/views/playlist/CollectionPage.vue
@@ -14,62 +14,26 @@
           </template>
           <template v-else-if="topTiers">
             <div class="tier-section">
-              <template v-if="tier0.length">
-                <div class="tier-heading">{{ getTierLabel(0, topTiers) }}</div>
-                <VueDraggable
-                  v-model="tier0"
-                  v-bind="dragOptions"
-                  :class="['tier-grid', 'tier-grid-0', { 'draggable-grid': !dragOptions.disabled }]"
-                  @end="handleTopTierEnd"
-                >
-                  <Album
-                    v-for="item in tier0"
-                    :key="item.id"
-                    :album="item"
-                    :rank="rankOf(item.id)"
-                    can-delete
-                    can-save
-                    with-artists
-                  />
-                </VueDraggable>
-              </template>
-              <template v-if="tier1.length">
-                <div class="tier-heading">{{ getTierLabel(1, topTiers) }}</div>
-                <VueDraggable
-                  v-model="tier1"
-                  v-bind="dragOptions"
-                  :class="['tier-grid', 'tier-grid-1', { 'draggable-grid': !dragOptions.disabled }]"
-                  @end="handleTopTierEnd"
-                >
-                  <Album
-                    v-for="item in tier1"
-                    :key="item.id"
-                    :album="item"
-                    :rank="rankOf(item.id)"
-                    can-delete
-                    can-save
-                    with-artists
-                  />
-                </VueDraggable>
-              </template>
-              <template v-if="tier2.length">
-                <div class="tier-heading">{{ getTierLabel(2, topTiers) }}</div>
-                <VueDraggable
-                  v-model="tier2"
-                  v-bind="dragOptions"
-                  :class="['tier-grid', 'tier-grid-2', { 'draggable-grid': !dragOptions.disabled }]"
-                  @end="handleTopTierEnd"
-                >
-                  <Album
-                    v-for="item in tier2"
-                    :key="item.id"
-                    :album="item"
-                    :rank="rankOf(item.id)"
-                    can-delete
-                    can-save
-                    with-artists
-                  />
-                </VueDraggable>
+              <template v-for="(group, i) in topTierGroups" :key="i">
+                <template v-if="group.length">
+                  <div class="tier-heading">{{ getTierLabel(i, topTiers) }}</div>
+                  <VueDraggable
+                    v-model="topTierGroups[i]"
+                    v-bind="dragOptions"
+                    :class="['tier-grid', `tier-grid-${i}`, { 'draggable-grid': !dragOptions.disabled }]"
+                    @end="handleTopTierEnd"
+                  >
+                    <Album
+                      v-for="item in group"
+                      :key="item.id"
+                      :album="item"
+                      :rank="rankOf(item.id)"
+                      can-delete
+                      can-save
+                      with-artists
+                    />
+                  </VueDraggable>
+                </template>
               </template>
             </div>
           </template>
@@ -189,18 +153,16 @@ import { useSidebar } from "@/components/sidebar/SidebarStore";
 import Loader from "@/components/ui/LoadingDots.vue";
 import PageFit from "@/components/ui/PageFit.vue";
 import PageScroller from "@/components/ui/PageScroller.vue";
+import { useCollectionRanking } from "@/composables/useCollectionRanking";
 import {
   buildCollectionDescription,
-  buildRankIndex,
   displayTierLabel,
   getTierColor,
   getTierLabel,
   groupByTierList,
-  parseCollectionRankingMode,
   splitTopTiers,
   stripCollectionTags,
   TierList,
-  TopTiers,
   UNSORTED_TIER_LABEL,
 } from "@/helpers/collectionOptions";
 import { notification } from "@/helpers/notifications";
@@ -215,10 +177,8 @@ const albumList = ref<AlbumSimplified[]>([]);
 const authStore = useAuth();
 const isDragging = ref(false);
 const scrollerRef = ref<InstanceType<typeof PageScroller>>();
-const tier0 = ref<AlbumSimplified[]>([]);
-const tier1 = ref<AlbumSimplified[]>([]);
-const tier2 = ref<AlbumSimplified[]>([]);
 const tierGroups = ref<AlbumSimplified[][]>([]);
+const topTierGroups = ref<AlbumSimplified[][]>([[], [], []]);
 const unsortedCanScrollLeft = ref(false);
 const unsortedCanScrollRight = ref(false);
 const unsortedScrollRef = ref<HTMLElement | null>(null);
@@ -236,14 +196,8 @@ const albumListFiltered = computed<AlbumSimplified[]>(() =>
   }),
 );
 
-const rankIndex = computed(() => buildRankIndex(albumList.value));
-const rankingMode = computed(() => parseCollectionRankingMode(playlistStore.playlist.description));
-const topTiers = computed<null | TopTiers>(() =>
-  rankingMode.value.type === "top" ? rankingMode.value.tiers : null,
-);
-const tierList = computed<null | TierList>(() =>
-  rankingMode.value.type === "tierlist" ? rankingMode.value.tiers : null,
-);
+const description = computed(() => playlistStore.playlist.description);
+const { rankOf, tierList, topTiers } = useCollectionRanking(description, albumList);
 
 const AUTO_SCROLL_SENSITIVITY = 150;
 const AUTO_SCROLL_MAX_SPEED = 100;
@@ -309,11 +263,7 @@ function handleTierListEnd(): void {
 }
 
 function handleTopTierEnd(): void {
-  applyReorder([...tier0.value, ...tier1.value, ...tier2.value]);
-}
-
-function rankOf(id: string): number {
-  return (rankIndex.value.get(id) ?? -1) + 1;
+  applyReorder(topTierGroups.value.flat());
 }
 
 function scrollUnsorted(direction: -1 | 1): void {
@@ -330,11 +280,16 @@ function scrollUnsorted(direction: -1 | 1): void {
  * shrinking — it always absorbs whatever remains.
  */
 function shrinkTiersForRemovedAlbums(list: TierList, removedIds: string[]): null | TierList {
+  const tierIndexByAlbumId = new Map<string, number>();
+  tierGroups.value.forEach((group, tierIndex) => {
+    group.forEach((album) => tierIndexByAlbumId.set(album.id, tierIndex));
+  });
+
   const decrements = new Array<number>(list.length).fill(0);
   let matched = false;
   removedIds.forEach((id) => {
-    const tierIndex = tierGroups.value.findIndex((group) => group.some((album) => album.id === id));
-    if (tierIndex === -1 || tierIndex >= list.length) return;
+    const tierIndex = tierIndexByAlbumId.get(id);
+    if (tierIndex === undefined || tierIndex >= list.length) return;
     decrements[tierIndex]++;
     matched = true;
   });
@@ -399,13 +354,7 @@ function syncTierSizesToDescription(): void {
 }
 
 function syncTopTiers(): void {
-  if (!topTiers.value) {
-    tier0.value = [];
-    tier1.value = [];
-    tier2.value = [];
-    return;
-  }
-  [tier0.value, tier1.value, tier2.value] = splitTopTiers(albumList.value, topTiers.value);
+  topTierGroups.value = topTiers.value ? splitTopTiers(albumList.value, topTiers.value) : [[], [], []];
 }
 
 function updateUnsortedScrollState(): void {

--- a/src/views/playlist/CollectionPage.vue
+++ b/src/views/playlist/CollectionPage.vue
@@ -159,6 +159,7 @@ import { instance } from "@/api";
 import Album from "@/components/album/AlbumIndex.vue";
 import { useConfig } from "@/components/config/ConfigStore";
 import Header from "@/components/playlist/PlaylistHeader.vue";
+import { useSidebar } from "@/components/sidebar/SidebarStore";
 import Loader from "@/components/ui/LoadingDots.vue";
 import PageFit from "@/components/ui/PageFit.vue";
 import PageScroller from "@/components/ui/PageScroller.vue";
@@ -315,32 +316,32 @@ function syncNewPositions(event: { newIndex?: number; oldIndex?: number }): void
  * reflected in the stored sizes causes the fixed-size recompute to pull an
  * item up from the next tier to fill the gap. Deletions don't go through
  * handleTierListEnd (they're triggered from the Album component itself), so
- * this watcher detects a shrunk albumList, finds which tier the removed
- * album belonged to (from the last known grouping), and shrinks that tier's
- * stored size to match before the normal slice-based recompute runs.
+ * this watcher diffs against the last known album ids on every change (not
+ * just when the list shrinks — an add and a remove can land in the same
+ * tick and leave the length unchanged) to find which tier lost an album,
+ * and shrinks that tier's stored size to match before the normal
+ * slice-based recompute runs.
  */
-let previousTierAlbumList: AlbumSimplified[] = [];
+let previousTierAlbumIds: Set<string> = new Set();
 
 function syncTierGroups(): void {
   const list = tierList.value;
   if (!list) {
     tierGroups.value = [];
-    previousTierAlbumList = [];
+    previousTierAlbumIds = new Set();
     return;
   }
 
-  if (albumList.value.length < previousTierAlbumList.length) {
-    const remainingIds = new Set(albumList.value.map((album) => album.id));
-    const removedIds = previousTierAlbumList.filter((album) => !remainingIds.has(album.id)).map((album) => album.id);
-    const adjustedList = shrinkTiersForRemovedAlbums(list, removedIds);
-    if (adjustedList) {
-      previousTierAlbumList = albumList.value;
-      writeTierListDescription(adjustedList);
-      return;
-    }
+  const currentIds = new Set(albumList.value.map((album) => album.id));
+  const removedIds = [...previousTierAlbumIds].filter((id) => !currentIds.has(id));
+  const adjustedList = removedIds.length ? shrinkTiersForRemovedAlbums(list, removedIds) : null;
+  if (adjustedList) {
+    previousTierAlbumIds = currentIds;
+    writeTierListDescription(adjustedList);
+    return;
   }
 
-  previousTierAlbumList = albumList.value;
+  previousTierAlbumIds = currentIds;
   tierGroups.value = groupByTierList(albumList.value, list);
 }
 
@@ -377,11 +378,14 @@ function writeTierListDescription(updatedList: TierList): void {
   if (newDescription === playlistStore.playlist.description) return;
 
   const previousDescription = playlistStore.playlist.description;
+  const sidebarCollection = useSidebar().collections.find((collection) => collection.id === playlistStore.playlist.id);
   playlistStore.playlist.description = newDescription;
+  if (sidebarCollection) sidebarCollection.description = newDescription;
   instance()
     .put(`playlists/${playlistStore.playlist.id}`, { description: newDescription })
     .catch(() => {
       playlistStore.playlist.description = previousDescription;
+      if (sidebarCollection) sidebarCollection.description = previousDescription;
       notification({ msg: "Unable to update the tier list. Please try again.", type: NotificationType.Error });
     });
 }

--- a/src/views/playlist/CollectionPage.vue
+++ b/src/views/playlist/CollectionPage.vue
@@ -7,44 +7,75 @@
       <div class="collection">
         <Header no-cover no-duration with-filter />
         <div class="content">
-          <template v-if="playlistStore.filter === ''">
-            <VueDraggable
-              v-model="albumList"
-              :animation="150"
-              :delay="200"
-              :disabled="playlistStore.playlist.owner.id !== authStore.me?.id"
-              :force-fallback="true"
-              :scroll-sensitivity="100"
-              :scroll-speed="15"
-              class="album-list"
-              @end="syncNewPositions"
-            >
-              <Album
-                v-for="item in albumList"
-                :key="item.id"
-                :album="item"
-                :class="topTiers ? tierClassFor(item.id) : undefined"
-                :data-tier-label="topTiers && isTierStart(item.id) ? tierLabelFor(item.id) : undefined"
-                :rank="topTiers ? rankOf(item.id) : undefined"
-                can-delete
-                can-save
-                with-artists
-              />
-            </VueDraggable>
+          <template v-if="playlistStore.filter !== ''">
+            <div class="album-list">
+              <Album v-for="item in albumListFiltered" :key="item.id" :album="item" can-delete can-save with-artists />
+            </div>
           </template>
-          <div v-else class="album-list">
-            <Album
-              v-for="item in albumListFiltered"
-              :key="item.id"
-              :album="item"
-              :class="topTiers ? tierClassFor(item.id) : undefined"
-              :data-tier-label="topTiers && isTierStart(item.id) ? tierLabelFor(item.id) : undefined"
-              :rank="topTiers ? rankOf(item.id) : undefined"
-              can-delete
-              can-save
-              with-artists
-            />
-          </div>
+          <template v-else-if="topTiers">
+            <div class="tier-section">
+              <template v-if="tier0.length">
+                <div class="tier-heading">{{ getTierLabel(0, topTiers) }}</div>
+                <VueDraggable
+                  v-model="tier0"
+                  v-bind="dragOptions"
+                  class="tier-grid tier-grid-0"
+                  @end="(event) => handleTierEnd(0, event)"
+                >
+                  <Album
+                    v-for="item in tier0"
+                    :key="item.id"
+                    :album="item"
+                    :rank="rankOf(item.id)"
+                    can-delete
+                    can-save
+                    with-artists
+                  />
+                </VueDraggable>
+              </template>
+              <template v-if="tier1.length">
+                <div class="tier-heading">{{ getTierLabel(1, topTiers) }}</div>
+                <VueDraggable
+                  v-model="tier1"
+                  v-bind="dragOptions"
+                  class="tier-grid tier-grid-1"
+                  @end="(event) => handleTierEnd(1, event)"
+                >
+                  <Album
+                    v-for="item in tier1"
+                    :key="item.id"
+                    :album="item"
+                    :rank="rankOf(item.id)"
+                    can-delete
+                    can-save
+                    with-artists
+                  />
+                </VueDraggable>
+              </template>
+              <template v-if="tier2.length">
+                <div class="tier-heading">{{ getTierLabel(2, topTiers) }}</div>
+                <VueDraggable
+                  v-model="tier2"
+                  v-bind="dragOptions"
+                  class="tier-grid tier-grid-2"
+                  @end="(event) => handleTierEnd(2, event)"
+                >
+                  <Album
+                    v-for="item in tier2"
+                    :key="item.id"
+                    :album="item"
+                    :rank="rankOf(item.id)"
+                    can-delete
+                    can-save
+                    with-artists
+                  />
+                </VueDraggable>
+              </template>
+            </div>
+          </template>
+          <VueDraggable v-else v-model="albumList" v-bind="dragOptions" class="album-list" @end="syncNewPositions">
+            <Album v-for="item in albumList" :key="item.id" :album="item" can-delete can-save with-artists />
+          </VueDraggable>
         </div>
       </div>
     </PageFit>
@@ -61,7 +92,7 @@ import Header from "@/components/playlist/PlaylistHeader.vue";
 import Loader from "@/components/ui/LoadingDots.vue";
 import PageFit from "@/components/ui/PageFit.vue";
 import PageScroller from "@/components/ui/PageScroller.vue";
-import { getTierForIndex, getTierLabel, parseTopTiers, TopTiers } from "@/helpers/collectionOptions";
+import { getTierLabel, parseTopTiers, TopTiers } from "@/helpers/collectionOptions";
 import { removeDuplicatesAlbums } from "@/helpers/removeDuplicate";
 import { useAuth } from "@/views/auth/AuthStore";
 import { usePlaylist } from "@/views/playlist/PlaylistStore";
@@ -71,6 +102,9 @@ const playlistStore = usePlaylist();
 const albumList = ref<AlbumSimplified[]>([]);
 const authStore = useAuth();
 const scrollerRef = ref<InstanceType<typeof PageScroller>>();
+const tier0 = ref<AlbumSimplified[]>([]);
+const tier1 = ref<AlbumSimplified[]>([]);
+const tier2 = ref<AlbumSimplified[]>([]);
 const syncAlbumList = (): void => {
   albumList.value = removeDuplicatesAlbums(playlistStore.tracks.map((a) => a.item.album));
 };
@@ -87,15 +121,24 @@ const albumListFiltered = computed<AlbumSimplified[]>(() =>
 
 const topTiers = computed<null | TopTiers>(() => parseTopTiers(playlistStore.playlist.description));
 
-function indexOfAlbum(id: string): number {
-  return albumList.value.findIndex((album) => album.id === id);
+const dragOptions = computed(() => ({
+  animation: 150,
+  delay: 200,
+  disabled: playlistStore.playlist.owner.id !== authStore.me?.id,
+  forceFallback: true,
+  scrollSensitivity: 100,
+  scrollSpeed: 15,
+}));
+
+function handleTierEnd(tierIndex: 0 | 1 | 2, event: { newIndex?: number; oldIndex?: number }): void {
+  if (event.oldIndex === undefined || event.newIndex === undefined) return;
+  const offset = tierOffset(tierIndex);
+  playlistStore.updateCollectionPosition(offset + event.oldIndex, offset + event.newIndex);
+  albumList.value = [...tier0.value, ...tier1.value, ...tier2.value];
 }
 
-function isTierStart(id: string): boolean {
-  if (!topTiers.value) return false;
-  const index = indexOfAlbum(id);
-  if (index === 0) return true;
-  return getTierForIndex(index, topTiers.value) !== getTierForIndex(index - 1, topTiers.value);
+function indexOfAlbum(id: string): number {
+  return albumList.value.findIndex((album) => album.id === id);
 }
 
 function rankOf(id: string): number {
@@ -107,20 +150,27 @@ function syncNewPositions(event: { newIndex?: number; oldIndex?: number }): void
   playlistStore.updateCollectionPosition(event.oldIndex, event.newIndex);
 }
 
-function tierClassFor(id: string): string {
-  const tier = tierOf(id);
-  return tier === null ? "" : `tier-${tier}`;
+function syncTiers(): void {
+  if (!topTiers.value) {
+    tier0.value = [];
+    tier1.value = [];
+    tier2.value = [];
+    return;
+  }
+  const [big, medium] = topTiers.value;
+  tier0.value = albumList.value.slice(0, big);
+  tier1.value = albumList.value.slice(big, big + medium);
+  tier2.value = albumList.value.slice(big + medium);
 }
 
-function tierLabelFor(id: string): string {
-  const tier = tierOf(id);
-  return tier === null || !topTiers.value ? "" : getTierLabel(tier, topTiers.value);
+function tierOffset(tierIndex: 0 | 1 | 2): number {
+  if (!topTiers.value) return 0;
+  if (tierIndex === 0) return 0;
+  if (tierIndex === 1) return topTiers.value[0];
+  return topTiers.value[0] + topTiers.value[1];
 }
 
-function tierOf(id: string): 0 | 1 | 2 | null {
-  if (!topTiers.value) return null;
-  return getTierForIndex(indexOfAlbum(id), topTiers.value);
-}
+watch([albumList, topTiers], syncTiers, { immediate: true });
 
 watch(
   () => playlistStore.tracks,
@@ -157,7 +207,6 @@ playlistStore.clean().finally(() => {
 
   display: grid;
   gap: 2rem;
-  grid-auto-flow: dense;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   padding: 2rem 5rem;
   padding-left: $padd;
@@ -212,28 +261,51 @@ playlistStore.clean().finally(() => {
   place-content: center;
 }
 
-/* stylelint-disable-next-line selector-pseudo-class-no-unknown */
-:deep(.tier-0) {
-  grid-column: span 2;
-  grid-row: span 2;
+.tier-section {
+  padding: 1rem 5rem 2rem;
+
+  @include responsive.tablet {
+    padding: 1rem 1.5rem 1.5rem;
+  }
+
+  @include responsive.mobile {
+    padding: 1rem;
+  }
 }
 
-/* stylelint-disable-next-line selector-pseudo-class-no-unknown */
-:deep(.tier-2) {
-  transform: scale(0.85);
-  transform-origin: top left;
-}
-
-/* stylelint-disable-next-line selector-pseudo-class-no-unknown */
-:deep(.tier-start)::before {
-  content: attr(data-tier-label);
-  display: block;
+.tier-heading {
+  background-color: var(--bg-color);
+  border-radius: 0.4rem;
 
   @include font-bold;
 
-  font-size: var(--font-size-sm);
-  opacity: 0.5;
-  position: absolute;
-  top: -1.8rem;
+  font-size: var(--font-size-lg);
+  margin: 2rem 0 1rem;
+  padding: 0.7rem 1.2rem;
+
+  &:first-child {
+    margin-top: 0;
+  }
+}
+
+.tier-grid {
+  display: grid;
+  gap: 2rem;
+
+  @include responsive.mobile {
+    gap: 1rem;
+  }
+}
+
+.tier-grid-0 {
+  grid-template-columns: repeat(auto-fill, minmax(15rem, 1fr));
+}
+
+.tier-grid-1 {
+  grid-template-columns: repeat(auto-fill, minmax(10rem, 1fr));
+}
+
+.tier-grid-2 {
+  grid-template-columns: repeat(auto-fill, minmax(7rem, 1fr));
 }
 </style>

--- a/src/views/playlist/CollectionPage.vue
+++ b/src/views/playlist/CollectionPage.vue
@@ -93,6 +93,7 @@
                       { 'draggable-grid': !dragOptions.disabled },
                     ]"
                     @end="handleTierListEnd"
+                    @start="isDragging = true"
                   >
                     <Album
                       v-for="item in tierGroups[i]"
@@ -100,37 +101,62 @@
                       :album="item"
                       can-delete
                       can-save
+                      :dragging="isDragging"
+                      hover-metas
                       with-artists
                     />
                   </VueDraggable>
                 </div>
               </template>
-              <div class="tier-row" :class="{ 'tier-row-side': configStore.tierListSideLabels }">
+              <div class="tier-row-unsorted" :class="{ 'tier-row-side': configStore.tierListSideLabels }">
                 <div
                   class="tier-heading tier-heading-unsorted"
                   :class="{ 'tier-heading-side': configStore.tierListSideLabels }"
                 >
                   {{ UNSORTED_TIER_LABEL }}
                 </div>
-                <VueDraggable
-                  v-model="tierGroups[tierList.length]"
-                  v-bind="dragOptions"
-                  class="tier-grid"
-                  :class="[
-                    configStore.tierListSideLabels ? 'tier-grid-side' : 'tier-grid-dynamic',
-                    { 'draggable-grid': !dragOptions.disabled },
-                  ]"
-                  @end="handleTierListEnd"
-                >
-                  <Album
-                    v-for="item in tierGroups[tierList.length]"
-                    :key="item.id"
-                    :album="item"
-                    can-delete
-                    can-save
-                    with-artists
-                  />
-                </VueDraggable>
+                <div class="unsorted-scroll-wrap">
+                  <button
+                    class="scroll-arrow"
+                    :disabled="!unsortedCanScrollLeft"
+                    title="Scroll left"
+                    type="button"
+                    @click="scrollUnsorted(-1)"
+                  >
+                    <i class="icon-arrow-left" />
+                  </button>
+                  <div ref="unsortedScrollRef" class="unsorted-scroll" @scroll="updateUnsortedScrollState">
+                    <VueDraggable
+                      v-model="tierGroups[tierList.length]"
+                      v-bind="dragOptions"
+                      class="tier-grid tier-grid-unsorted"
+                      :class="{ 'draggable-grid': !dragOptions.disabled }"
+                      @end="handleTierListEnd"
+                      @start="isDragging = true"
+                    >
+                      <Album
+                        v-for="item in tierGroups[tierList.length]"
+                        :key="item.id"
+                        :album="item"
+                        can-delete
+                        can-save
+                        :dragging="isDragging"
+                        hover-metas
+                        metas-above
+                        with-artists
+                      />
+                    </VueDraggable>
+                  </div>
+                  <button
+                    class="scroll-arrow"
+                    :disabled="!unsortedCanScrollRight"
+                    title="Scroll right"
+                    type="button"
+                    @click="scrollUnsorted(1)"
+                  >
+                    <i class="icon-arrow-right" />
+                  </button>
+                </div>
               </div>
             </div>
           </template>
@@ -187,11 +213,15 @@ const configStore = useConfig();
 const playlistStore = usePlaylist();
 const albumList = ref<AlbumSimplified[]>([]);
 const authStore = useAuth();
+const isDragging = ref(false);
 const scrollerRef = ref<InstanceType<typeof PageScroller>>();
 const tier0 = ref<AlbumSimplified[]>([]);
 const tier1 = ref<AlbumSimplified[]>([]);
 const tier2 = ref<AlbumSimplified[]>([]);
 const tierGroups = ref<AlbumSimplified[][]>([]);
+const unsortedCanScrollLeft = ref(false);
+const unsortedCanScrollRight = ref(false);
+const unsortedScrollRef = ref<HTMLElement | null>(null);
 const syncAlbumList = (): void => {
   albumList.value = removeDuplicatesAlbums(playlistStore.tracks.map((a) => a.item.album));
 };
@@ -273,6 +303,7 @@ function findMove(previous: AlbumSimplified[], next: AlbumSimplified[]): { newIn
 }
 
 function handleTierListEnd(): void {
+  isDragging.value = false;
   applyReorder(tierGroups.value.flat());
   syncTierSizesToDescription();
 }
@@ -283,6 +314,12 @@ function handleTopTierEnd(): void {
 
 function rankOf(id: string): number {
   return (rankIndex.value.get(id) ?? -1) + 1;
+}
+
+function scrollUnsorted(direction: -1 | 1): void {
+  const el = unsortedScrollRef.value;
+  if (!el) return;
+  el.scrollBy({ behavior: "smooth", left: direction * el.clientWidth * 0.9 });
 }
 
 /**
@@ -371,6 +408,13 @@ function syncTopTiers(): void {
   [tier0.value, tier1.value, tier2.value] = splitTopTiers(albumList.value, topTiers.value);
 }
 
+function updateUnsortedScrollState(): void {
+  const el = unsortedScrollRef.value;
+  if (!el) return;
+  unsortedCanScrollLeft.value = el.scrollLeft > 0;
+  unsortedCanScrollRight.value = el.scrollLeft + el.clientWidth < el.scrollWidth - 1;
+}
+
 /** Writes an updated tier list to the description (optimistic, background PUT, rolls back on failure). */
 function writeTierListDescription(updatedList: TierList): void {
   const freeText = stripCollectionTags(playlistStore.playlist.description);
@@ -392,6 +436,7 @@ function writeTierListDescription(updatedList: TierList): void {
 
 watch([albumList, topTiers], syncTopTiers, { immediate: true });
 watch([albumList, tierList], syncTierGroups, { immediate: true });
+watch(tierGroups, updateUnsortedScrollState, { flush: "post" });
 
 watch(
   () => playlistStore.tracks,
@@ -483,6 +528,11 @@ playlistStore.clean().finally(() => {
 }
 
 .tier-section {
+  // .content is display: contents, so .tier-section is a direct grid item of
+  // .collection — its default min-width: auto lets the Unsorted row's
+  // intrinsic content width (before overflow-x clips it) push the whole grid,
+  // and so the page, wider. min-width: 0 opts it out of that contribution.
+  min-width: 0;
   padding: 1rem 5rem 2rem;
 
   @include responsive.tablet {
@@ -502,6 +552,35 @@ playlistStore.clean().finally(() => {
   align-items: stretch;
   display: flex;
   margin-bottom: 1.5rem;
+}
+
+// Sticky requires an actual box (display: contents, used by .tier-row, opts an
+// element out of sticky positioning entirely), so the Unsorted row gets its own
+// always-boxed variant instead of reusing .tier-row.
+.tier-row-unsorted {
+  background-color: var(--bg-color-darker);
+  bottom: 0;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  padding-bottom: 1rem;
+  position: sticky;
+  z-index: 2;
+
+  &.tier-row-side {
+    flex-direction: row;
+  }
+
+  &::before {
+    background-image: linear-gradient(to top, var(--bg-color-darker) 0%, transparent 100%);
+    bottom: 100%;
+    content: '';
+    height: 20px;
+    left: 0;
+    pointer-events: none;
+    position: absolute;
+    right: 0;
+  }
 }
 
 .tier-heading {
@@ -601,6 +680,78 @@ playlistStore.clean().finally(() => {
   /* stylelint-disable-next-line selector-pseudo-class-no-unknown */
   :deep(.sortable-chosen) {
     cursor: grabbing;
+  }
+}
+
+.unsorted-scroll-wrap {
+  align-items: center;
+  background-color: var(--bg-color);
+  border-radius: 0 0.4rem 0.4rem 0;
+  display: flex;
+  flex: 1;
+  gap: 0.5rem;
+  min-width: 0;
+  padding: 0 1rem;
+}
+
+// Fixed to a single row (grid-template-rows) with new columns created as
+// needed (grid-auto-flow: column) instead of wrapping — the Unsorted bucket
+// can grow unbounded, so it scrolls sideways within .unsorted-scroll rather
+// than pushing the page taller. flex + min-width: 0 are required for that:
+// flex items default to min-width: auto, which without this would let the
+// grid's intrinsic content width blow out the container instead of
+// scrolling inside it.
+.unsorted-scroll {
+  flex: 1;
+  min-width: 0;
+  overflow-x: auto;
+  scroll-behavior: smooth;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+.tier-grid-unsorted {
+  background-color: var(--bg-color);
+  border-radius: 0.4rem;
+  display: grid;
+  gap: 1rem;
+  grid-auto-columns: 7rem;
+  grid-auto-flow: column;
+  grid-template-rows: 7rem;
+  padding: 1rem;
+  width: max-content;
+
+  @include responsive.mobile {
+    gap: 1rem;
+    grid-auto-columns: 6rem;
+    grid-template-rows: 6rem;
+  }
+}
+
+.scroll-arrow {
+  align-items: center;
+  background-color: var(--bg-color-light);
+  border: 0;
+  border-radius: 50%;
+  color: currentcolor;
+  cursor: pointer;
+  display: flex;
+  flex-shrink: 0;
+  font-size: var(--font-size-lg);
+  height: 2.4rem;
+  justify-content: center;
+  width: 2.4rem;
+
+  &:hover:not(:disabled) {
+    background-color: var(--bg-color-lighter);
+  }
+
+  &:disabled {
+    cursor: default;
+    opacity: 0.3;
   }
 }
 </style>

--- a/src/views/playlist/CollectionPage.vue
+++ b/src/views/playlist/CollectionPage.vue
@@ -15,8 +15,7 @@
           <template v-else-if="topTiers">
             <div class="tier-section">
               <template v-for="(group, i) in topTierGroups" :key="i">
-                <template v-if="group.length">
-                  <div class="tier-heading">{{ getTierLabel(i, topTiers) }}</div>
+                <TierRow v-if="group.length" :label="getTierLabel(i, topTiers)">
                   <VueDraggable
                     v-model="topTierGroups[i]"
                     v-bind="dragOptions"
@@ -33,21 +32,18 @@
                       with-artists
                     />
                   </VueDraggable>
-                </template>
+                </TierRow>
               </template>
             </div>
           </template>
           <template v-else-if="tierList">
             <div class="tier-section">
               <template v-for="(tier, i) in tierList" :key="i">
-                <div class="tier-row" :class="{ 'tier-row-side': configStore.tierListSideLabels }">
-                  <div
-                    class="tier-heading tier-heading-colored"
-                    :class="{ 'tier-heading-side': configStore.tierListSideLabels }"
-                    :style="{ backgroundColor: getTierColor(i, tierList.length) }"
-                  >
-                    {{ displayTierLabel(tier.label) }}
-                  </div>
+                <TierRow
+                  :color="getTierColor(i, tierList.length)"
+                  :label="displayTierLabel(tier.label)"
+                  :side-layout="configStore.tierListSideLabels"
+                >
                   <VueDraggable
                     v-model="tierGroups[i]"
                     v-bind="dragOptions"
@@ -70,58 +66,35 @@
                       with-artists
                     />
                   </VueDraggable>
-                </div>
+                </TierRow>
               </template>
-              <div class="tier-row-unsorted" :class="{ 'tier-row-side': configStore.tierListSideLabels }">
-                <div
-                  class="tier-heading tier-heading-unsorted"
-                  :class="{ 'tier-heading-side': configStore.tierListSideLabels }"
+              <TierRow
+                :label="UNSORTED_TIER_LABEL"
+                scrollable
+                :side-layout="configStore.tierListSideLabels"
+                unsorted
+              >
+                <VueDraggable
+                  v-model="tierGroups[tierList.length]"
+                  v-bind="dragOptions"
+                  class="tier-grid tier-grid-unsorted"
+                  :class="{ 'draggable-grid': !dragOptions.disabled }"
+                  @end="handleTierListEnd"
+                  @start="isDragging = true"
                 >
-                  {{ UNSORTED_TIER_LABEL }}
-                </div>
-                <div class="unsorted-scroll-wrap">
-                  <button
-                    class="scroll-arrow"
-                    :disabled="!unsortedCanScrollLeft"
-                    title="Scroll left"
-                    type="button"
-                    @click="scrollUnsorted(-1)"
-                  >
-                    <i class="icon-arrow-left" />
-                  </button>
-                  <div ref="unsortedScrollRef" class="unsorted-scroll" @scroll="updateUnsortedScrollState">
-                    <VueDraggable
-                      v-model="tierGroups[tierList.length]"
-                      v-bind="dragOptions"
-                      class="tier-grid tier-grid-unsorted"
-                      :class="{ 'draggable-grid': !dragOptions.disabled }"
-                      @end="handleTierListEnd"
-                      @start="isDragging = true"
-                    >
-                      <Album
-                        v-for="item in tierGroups[tierList.length]"
-                        :key="item.id"
-                        :album="item"
-                        can-delete
-                        can-save
-                        :dragging="isDragging"
-                        hover-metas
-                        metas-above
-                        with-artists
-                      />
-                    </VueDraggable>
-                  </div>
-                  <button
-                    class="scroll-arrow"
-                    :disabled="!unsortedCanScrollRight"
-                    title="Scroll right"
-                    type="button"
-                    @click="scrollUnsorted(1)"
-                  >
-                    <i class="icon-arrow-right" />
-                  </button>
-                </div>
-              </div>
+                  <Album
+                    v-for="item in tierGroups[tierList.length]"
+                    :key="item.id"
+                    :album="item"
+                    can-delete
+                    can-save
+                    :dragging="isDragging"
+                    hover-metas
+                    metas-above
+                    with-artists
+                  />
+                </VueDraggable>
+              </TierRow>
             </div>
           </template>
           <VueDraggable
@@ -149,22 +122,26 @@ import { instance } from "@/api";
 import Album from "@/components/album/AlbumIndex.vue";
 import { useConfig } from "@/components/config/ConfigStore";
 import Header from "@/components/playlist/PlaylistHeader.vue";
+import TierRow from "@/components/playlist/TierRow.vue";
 import { useSidebar } from "@/components/sidebar/SidebarStore";
 import Loader from "@/components/ui/LoadingDots.vue";
 import PageFit from "@/components/ui/PageFit.vue";
 import PageScroller from "@/components/ui/PageScroller.vue";
 import { useCollectionRanking } from "@/composables/useCollectionRanking";
+import { findMove } from "@/helpers/arrayDiff";
 import {
   buildCollectionDescription,
   displayTierLabel,
   getTierColor,
   getTierLabel,
   groupByTierList,
+  shrinkTiersForRemovedAlbums,
   splitTopTiers,
   stripCollectionTags,
   TierList,
   UNSORTED_TIER_LABEL,
 } from "@/helpers/collectionOptions";
+import { computeAutoScrollDelta } from "@/helpers/dragAutoScroll";
 import { notification } from "@/helpers/notifications";
 import { removeDuplicatesAlbums } from "@/helpers/removeDuplicate";
 import { useAuth } from "@/views/auth/AuthStore";
@@ -179,9 +156,6 @@ const isDragging = ref(false);
 const scrollerRef = ref<InstanceType<typeof PageScroller>>();
 const tierGroups = ref<AlbumSimplified[][]>([]);
 const topTierGroups = ref<AlbumSimplified[][]>([[], [], []]);
-const unsortedCanScrollLeft = ref(false);
-const unsortedCanScrollRight = ref(false);
-const unsortedScrollRef = ref<HTMLElement | null>(null);
 const syncAlbumList = (): void => {
   albumList.value = removeDuplicatesAlbums(playlistStore.tracks.map((a) => a.item.album));
 };
@@ -211,20 +185,14 @@ function handleAutoScroll(
 ): "continue" | void {
   const pointerEvent = touchEvt?.touches?.length ? touchEvt.touches[0] : (originalEvent as MouseEvent);
   const rect = hoverTargetEl.getBoundingClientRect();
-  const distanceFromTop = pointerEvent.clientY - rect.top;
-  const distanceFromBottom = rect.bottom - pointerEvent.clientY;
-
-  if (distanceFromTop >= 0 && distanceFromTop < AUTO_SCROLL_SENSITIVITY) {
-    const ratio = 1 - distanceFromTop / AUTO_SCROLL_SENSITIVITY;
-    hoverTargetEl.scrollTop -= Math.ceil(AUTO_SCROLL_MAX_SPEED * ratio);
-    return;
-  }
-  if (distanceFromBottom >= 0 && distanceFromBottom < AUTO_SCROLL_SENSITIVITY) {
-    const ratio = 1 - distanceFromBottom / AUTO_SCROLL_SENSITIVITY;
-    hoverTargetEl.scrollTop += Math.ceil(AUTO_SCROLL_MAX_SPEED * ratio);
-    return;
-  }
-  return "continue";
+  const delta = computeAutoScrollDelta(
+    pointerEvent.clientY - rect.top,
+    rect.bottom - pointerEvent.clientY,
+    AUTO_SCROLL_SENSITIVITY,
+    AUTO_SCROLL_MAX_SPEED,
+  );
+  if (delta === null) return "continue";
+  hoverTargetEl.scrollTop += delta;
 }
 
 const dragOptions = computed(() => ({
@@ -244,18 +212,6 @@ function applyReorder(nextOrder: AlbumSimplified[]): void {
   albumList.value = nextOrder;
 }
 
-/**
- * Finds the single item that moved between two otherwise-identical lists by
- * locating the first index where they diverge and tracing that item's prior
- * position via its id.
- */
-function findMove(previous: AlbumSimplified[], next: AlbumSimplified[]): { newIndex: number; oldIndex: number } | null {
-  const newIndex = previous.findIndex((album, i) => album.id !== next[i]?.id);
-  if (newIndex === -1) return null;
-  const oldIndex = previous.findIndex((album) => album.id === next[newIndex].id);
-  return { newIndex, oldIndex };
-}
-
 function handleTierListEnd(): void {
   isDragging.value = false;
   applyReorder(tierGroups.value.flat());
@@ -264,37 +220,6 @@ function handleTierListEnd(): void {
 
 function handleTopTierEnd(): void {
   applyReorder(topTierGroups.value.flat());
-}
-
-function scrollUnsorted(direction: -1 | 1): void {
-  const el = unsortedScrollRef.value;
-  if (!el) return;
-  el.scrollBy({ behavior: "smooth", left: direction * el.clientWidth * 0.9 });
-}
-
-/**
- * Given the tiers a set of now-deleted albums used to belong to (looked up
- * from the last known grouping), decrements each affected tier's stored
- * size by how many of its items were removed. The Unsorted bucket (index
- * `list.length` in tierGroups, one past the stored tiers) never needs
- * shrinking — it always absorbs whatever remains.
- */
-function shrinkTiersForRemovedAlbums(list: TierList, removedIds: string[]): null | TierList {
-  const tierIndexByAlbumId = new Map<string, number>();
-  tierGroups.value.forEach((group, tierIndex) => {
-    group.forEach((album) => tierIndexByAlbumId.set(album.id, tierIndex));
-  });
-
-  const decrements = new Array<number>(list.length).fill(0);
-  let matched = false;
-  removedIds.forEach((id) => {
-    const tierIndex = tierIndexByAlbumId.get(id);
-    if (tierIndex === undefined || tierIndex >= list.length) return;
-    decrements[tierIndex]++;
-    matched = true;
-  });
-  if (!matched) return null;
-  return list.map((tier, index) => ({ ...tier, size: Math.max(tier.size - decrements[index], 0) }));
 }
 
 function syncNewPositions(event: { newIndex?: number; oldIndex?: number }): void {
@@ -326,7 +251,9 @@ function syncTierGroups(): void {
 
   const currentIds = new Set(albumList.value.map((album) => album.id));
   const removedIds = [...previousTierAlbumIds].filter((id) => !currentIds.has(id));
-  const adjustedList = removedIds.length ? shrinkTiersForRemovedAlbums(list, removedIds) : null;
+  const adjustedList = removedIds.length
+    ? shrinkTiersForRemovedAlbums(list, tierGroups.value, removedIds)
+    : null;
   if (adjustedList) {
     previousTierAlbumIds = currentIds;
     writeTierListDescription(adjustedList);
@@ -357,13 +284,6 @@ function syncTopTiers(): void {
   topTierGroups.value = topTiers.value ? splitTopTiers(albumList.value, topTiers.value) : [[], [], []];
 }
 
-function updateUnsortedScrollState(): void {
-  const el = unsortedScrollRef.value;
-  if (!el) return;
-  unsortedCanScrollLeft.value = el.scrollLeft > 0;
-  unsortedCanScrollRight.value = el.scrollLeft + el.clientWidth < el.scrollWidth - 1;
-}
-
 /** Writes an updated tier list to the description (optimistic, background PUT, rolls back on failure). */
 function writeTierListDescription(updatedList: TierList): void {
   const freeText = stripCollectionTags(playlistStore.playlist.description);
@@ -385,7 +305,6 @@ function writeTierListDescription(updatedList: TierList): void {
 
 watch([albumList, topTiers], syncTopTiers, { immediate: true });
 watch([albumList, tierList], syncTierGroups, { immediate: true });
-watch(tierGroups, updateUnsortedScrollState, { flush: "post" });
 
 watch(
   () => playlistStore.tracks,
@@ -493,88 +412,6 @@ playlistStore.clean().finally(() => {
   }
 }
 
-.tier-row {
-  display: contents;
-}
-
-.tier-row-side {
-  align-items: stretch;
-  display: flex;
-  margin-bottom: 1.5rem;
-}
-
-// Sticky requires an actual box (display: contents, used by .tier-row, opts an
-// element out of sticky positioning entirely), so the Unsorted row gets its own
-// always-boxed variant instead of reusing .tier-row.
-.tier-row-unsorted {
-  background-color: var(--bg-color-darker);
-  bottom: 0;
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
-  padding-bottom: 1rem;
-  position: sticky;
-  z-index: 2;
-
-  &.tier-row-side {
-    flex-direction: row;
-  }
-
-  &::before {
-    background-image: linear-gradient(to top, var(--bg-color-darker) 0%, transparent 100%);
-    bottom: 100%;
-    content: '';
-    height: 20px;
-    left: 0;
-    pointer-events: none;
-    position: absolute;
-    right: 0;
-  }
-}
-
-.tier-heading {
-  background-color: var(--bg-color);
-  border-radius: 0.4rem;
-  font-size: var(--font-size-lg);
-  line-break: anywhere;
-  margin: 2rem 0 1rem;
-  padding: 0.7rem 1.2rem;
-
-  @include font-bold;
-
-  &:first-child {
-    margin-top: 0;
-  }
-}
-
-.tier-heading-colored {
-  color: #fff;
-  text-shadow: 0 0.1rem 0.2rem rgb(0 0 0 / 40%);
-}
-
-.tier-heading-unsorted {
-  background-color: transparent;
-  border: 0.1rem dashed var(--bg-color-lighter);
-  color: var(--font-color-dark);
-  font-style: italic;
-  opacity: 0.7;
-}
-
-.tier-heading-side {
-  align-items: center;
-  border-radius: 0.4rem 0 0 0.4rem;
-  display: flex;
-  flex-shrink: 0;
-  justify-content: center;
-  margin: 0;
-  text-align: center;
-  width: 8rem;
-
-  @include responsive.mobile {
-    width: 5rem;
-  }
-}
-
 .tier-grid {
   display: grid;
   gap: 2rem;
@@ -632,36 +469,11 @@ playlistStore.clean().finally(() => {
   }
 }
 
-.unsorted-scroll-wrap {
-  align-items: center;
-  background-color: var(--bg-color);
-  border-radius: 0 0.4rem 0.4rem 0;
-  display: flex;
-  flex: 1;
-  gap: 0.5rem;
-  min-width: 0;
-  padding: 0 1rem;
-}
-
 // Fixed to a single row (grid-template-rows) with new columns created as
 // needed (grid-auto-flow: column) instead of wrapping — the Unsorted bucket
-// can grow unbounded, so it scrolls sideways within .unsorted-scroll rather
-// than pushing the page taller. flex + min-width: 0 are required for that:
-// flex items default to min-width: auto, which without this would let the
-// grid's intrinsic content width blow out the container instead of
-// scrolling inside it.
-.unsorted-scroll {
-  flex: 1;
-  min-width: 0;
-  overflow-x: auto;
-  scroll-behavior: smooth;
-  scrollbar-width: none;
-
-  &::-webkit-scrollbar {
-    display: none;
-  }
-}
-
+// can grow unbounded, so it scrolls sideways within TierRow's .unsorted-scroll
+// (which handles the container-level overflow/min-width containment) rather
+// than pushing the page taller.
 .tier-grid-unsorted {
   background-color: var(--bg-color);
   border-radius: 0.4rem;
@@ -680,27 +492,4 @@ playlistStore.clean().finally(() => {
   }
 }
 
-.scroll-arrow {
-  align-items: center;
-  background-color: var(--bg-color-light);
-  border: 0;
-  border-radius: 50%;
-  color: currentcolor;
-  cursor: pointer;
-  display: flex;
-  flex-shrink: 0;
-  font-size: var(--font-size-lg);
-  height: 2.4rem;
-  justify-content: center;
-  width: 2.4rem;
-
-  &:hover:not(:disabled) {
-    background-color: var(--bg-color-lighter);
-  }
-
-  &:disabled {
-    cursor: default;
-    opacity: 0.3;
-  }
-}
 </style>

--- a/src/views/playlist/CollectionPage.vue
+++ b/src/views/playlist/CollectionPage.vue
@@ -5,7 +5,7 @@
   <PageScroller v-else ref="scrollerRef">
     <PageFit>
       <div class="collection">
-        <Header no-cover no-duration with-filter />
+        <Header no-duration with-filter />
         <div class="content">
           <template v-if="playlistStore.filter !== ''">
             <div class="album-list">

--- a/src/views/playlist/PlaylistStore.ts
+++ b/src/views/playlist/PlaylistStore.ts
@@ -7,7 +7,7 @@ import { Playlist, PlaylistPage, PlaylistTrack } from "@/@types/Playlist";
 import { TrackToRemove } from "@/@types/Track";
 import { instance } from "@/api";
 import { useSidebar } from "@/components/sidebar/SidebarStore";
-import { buildCollectionDescription, parseTopTiers, stripCollectionTags } from "@/helpers/collectionOptions";
+import { buildCollectionDescription, parseCollectionRankingMode, stripCollectionTags } from "@/helpers/collectionOptions";
 import { isInLibrary, saveToLibrary } from "@/helpers/library";
 import { notification } from "@/helpers/notifications";
 import { cleanUrl } from "@/helpers/urls";
@@ -73,8 +73,8 @@ export const usePlaylist = defineStore("playlist", {
       const cleanName = stripCollectionTags(this.playlist.name);
       const rawDescription = stripCollectionTags(this.playlist.description);
       const cleanDescription = rawDescription === "No description" ? "" : rawDescription;
-      const topTiers = parseTopTiers(this.playlist.description);
-      const newDescription = buildCollectionDescription(cleanDescription, true, topTiers);
+      const rankingMode = parseCollectionRankingMode(this.playlist.description);
+      const newDescription = buildCollectionDescription(cleanDescription, true, rankingMode);
 
       try {
         await instance().put(`playlists/${this.playlist.id}`, { description: newDescription, name: cleanName });

--- a/src/views/playlist/PlaylistStore.ts
+++ b/src/views/playlist/PlaylistStore.ts
@@ -7,9 +7,11 @@ import { Playlist, PlaylistPage, PlaylistTrack } from "@/@types/Playlist";
 import { TrackToRemove } from "@/@types/Track";
 import { instance } from "@/api";
 import { useSidebar } from "@/components/sidebar/SidebarStore";
+import { buildCollectionDescription, parseTopTiers, stripCollectionTags } from "@/helpers/collectionOptions";
 import { isInLibrary, saveToLibrary } from "@/helpers/library";
 import { notification } from "@/helpers/notifications";
 import { cleanUrl } from "@/helpers/urls";
+import router from "@/router";
 
 export const usePlaylist = defineStore("playlist", {
   actions: {
@@ -64,6 +66,25 @@ export const usePlaylist = defineStore("playlist", {
             await this.getTracks(fixedUrl);
           }
         }
+      }
+    },
+
+    async migrateLegacyCollectionTag() {
+      const cleanName = stripCollectionTags(this.playlist.name);
+      const rawDescription = stripCollectionTags(this.playlist.description);
+      const cleanDescription = rawDescription === "No description" ? "" : rawDescription;
+      const topTiers = parseTopTiers(this.playlist.description);
+      const newDescription = buildCollectionDescription(cleanDescription, true, topTiers);
+
+      try {
+        await instance().put(`playlists/${this.playlist.id}`, { description: newDescription, name: cleanName });
+        this.playlist.name = cleanName;
+        this.playlist.description = newDescription;
+        useSidebar().refreshPlaylists();
+        notification({ msg: "Collection converted to the new format", type: NotificationType.Success });
+        router.push(`/collection/${this.playlist.id}`);
+      } catch {
+        notification({ msg: "Unable to convert this collection. Please try again.", type: NotificationType.Error });
       }
     },
 

--- a/src/views/playlist/SharedCollectionPage.vue
+++ b/src/views/playlist/SharedCollectionPage.vue
@@ -47,6 +47,23 @@
             </template>
           </div>
         </template>
+        <template v-else-if="tierList">
+          <div class="tier-section">
+            <template v-for="(tier, i) in tierList" :key="i">
+              <template v-if="tierGroups[i]?.length">
+                <div
+                  class="tier-heading tier-heading-colored"
+                  :style="{ backgroundColor: getTierColor(i, tierList.length) }"
+                >
+                  {{ displayTierLabel(tier.label) }}
+                </div>
+                <div class="tier-grid tier-grid-dynamic">
+                  <SharedAlbumCard v-for="album in tierGroups[i]" :key="album.id" :album="album" />
+                </div>
+              </template>
+            </template>
+          </div>
+        </template>
         <div v-else class="album-list">
           <SharedAlbumCard v-for="album in albumList" :key="album.id" :album="album" />
         </div>
@@ -69,7 +86,14 @@ import ButtonIndex from "@/components/ui/ButtonIndex.vue";
 import Loader from "@/components/ui/LoadingDots.vue";
 import PageFit from "@/components/ui/PageFit.vue";
 import PageScroller from "@/components/ui/PageScroller.vue";
-import { getTierLabel, parseTopTiers, TopTiers } from "@/helpers/collectionOptions";
+import {
+  displayTierLabel,
+  getTierColor,
+  getTierLabel,
+  parseCollectionRankingMode,
+  TierList,
+  TopTiers,
+} from "@/helpers/collectionOptions";
 import { fetchAllPages } from "@/helpers/pagination";
 import { publicSpotifyGet } from "@/helpers/publicSpotify";
 import { removeDuplicatesAlbums } from "@/helpers/removeDuplicate";
@@ -82,7 +106,11 @@ const error = ref("");
 const playlist = ref<Playlist>(defaultPlaylist);
 const albumList = ref<AlbumSimplified[]>([]);
 const beardifyUrl = absoluteRouteUrl(RouteName.Collection, props.id);
-const topTiers = computed<null | TopTiers>(() => parseTopTiers(playlist.value.description));
+const rankingMode = computed(() => parseCollectionRankingMode(playlist.value.description));
+const topTiers = computed<null | TopTiers>(() => (rankingMode.value.type === "top" ? rankingMode.value.tiers : null));
+const tierList = computed<null | TierList>(() =>
+  rankingMode.value.type === "tierlist" ? rankingMode.value.tiers : null,
+);
 
 const tier0 = computed<AlbumSimplified[]>(() => (topTiers.value ? albumList.value.slice(0, topTiers.value[0]) : []));
 const tier1 = computed<AlbumSimplified[]>(() =>
@@ -91,6 +119,19 @@ const tier1 = computed<AlbumSimplified[]>(() =>
 const tier2 = computed<AlbumSimplified[]>(() =>
   topTiers.value ? albumList.value.slice(topTiers.value[0] + topTiers.value[1]) : [],
 );
+
+const tierGroups = computed<AlbumSimplified[][]>(() => {
+  const list = tierList.value;
+  if (!list) return [];
+  let offset = 0;
+  return list.map((tier, index) => {
+    if (index === list.length - 1) return albumList.value.slice(offset);
+    const size = tier.size ?? 0;
+    const group = albumList.value.slice(offset, offset + size);
+    offset += size;
+    return group;
+  });
+});
 
 function errorMessage(err: unknown): string {
   if (!(err instanceof HTTPError)) return "This collection is unavailable. Please try again later.";
@@ -232,6 +273,11 @@ onMounted(async () => {
   }
 }
 
+.tier-heading-colored {
+  color: #fff;
+  text-shadow: 0 0.1rem 0.2rem rgb(0 0 0 / 40%);
+}
+
 .tier-grid {
   display: grid;
   gap: 2rem;
@@ -253,4 +299,7 @@ onMounted(async () => {
   grid-template-columns: repeat(auto-fill, minmax(7rem, 1fr));
 }
 
+.tier-grid-dynamic {
+  grid-template-columns: repeat(auto-fill, minmax(10rem, 1fr));
+}
 </style>

--- a/src/views/playlist/SharedCollectionPage.vue
+++ b/src/views/playlist/SharedCollectionPage.vue
@@ -27,38 +27,13 @@
         </header>
         <template v-if="topTiers">
           <div class="tier-section">
-            <template v-if="topTierGroups[0].length">
-              <div class="tier-heading">{{ getTierLabel(0, topTiers) }}</div>
-              <div class="tier-grid tier-grid-0">
-                <SharedAlbumCard
-                  v-for="album in topTierGroups[0]"
-                  :key="album.id"
-                  :album="album"
-                  :rank="rankOf(album.id)"
-                />
-              </div>
-            </template>
-            <template v-if="topTierGroups[1].length">
-              <div class="tier-heading">{{ getTierLabel(1, topTiers) }}</div>
-              <div class="tier-grid tier-grid-1">
-                <SharedAlbumCard
-                  v-for="album in topTierGroups[1]"
-                  :key="album.id"
-                  :album="album"
-                  :rank="rankOf(album.id)"
-                />
-              </div>
-            </template>
-            <template v-if="topTierGroups[2].length">
-              <div class="tier-heading">{{ getTierLabel(2, topTiers) }}</div>
-              <div class="tier-grid tier-grid-2">
-                <SharedAlbumCard
-                  v-for="album in topTierGroups[2]"
-                  :key="album.id"
-                  :album="album"
-                  :rank="rankOf(album.id)"
-                />
-              </div>
+            <template v-for="(group, i) in topTierGroups" :key="i">
+              <template v-if="group.length">
+                <div class="tier-heading">{{ getTierLabel(i, topTiers) }}</div>
+                <div :class="['tier-grid', `tier-grid-${i}`]">
+                  <SharedAlbumCard v-for="album in group" :key="album.id" :album="album" :rank="rankOf(album.id)" />
+                </div>
+              </template>
             </template>
           </div>
         </template>
@@ -129,18 +104,8 @@ import ButtonIndex from "@/components/ui/ButtonIndex.vue";
 import Loader from "@/components/ui/LoadingDots.vue";
 import PageFit from "@/components/ui/PageFit.vue";
 import PageScroller from "@/components/ui/PageScroller.vue";
-import {
-  buildRankIndex,
-  displayTierLabel,
-  getTierColor,
-  getTierLabel,
-  groupByTierList,
-  parseCollectionRankingMode,
-  splitTopTiers,
-  TierList,
-  TopTiers,
-  UNSORTED_TIER_LABEL,
-} from "@/helpers/collectionOptions";
+import { useCollectionRanking } from "@/composables/useCollectionRanking";
+import { displayTierLabel, getTierColor, getTierLabel, groupByTierList, splitTopTiers, UNSORTED_TIER_LABEL } from "@/helpers/collectionOptions";
 import { fetchAllPages } from "@/helpers/pagination";
 import { publicSpotifyGet } from "@/helpers/publicSpotify";
 import { removeDuplicatesAlbums } from "@/helpers/removeDuplicate";
@@ -154,13 +119,8 @@ const error = ref("");
 const playlist = ref<Playlist>(defaultPlaylist);
 const albumList = ref<AlbumSimplified[]>([]);
 const beardifyUrl = absoluteRouteUrl(RouteName.Collection, props.id);
-const rankingMode = computed(() => parseCollectionRankingMode(playlist.value.description));
-const topTiers = computed<null | TopTiers>(() => (rankingMode.value.type === "top" ? rankingMode.value.tiers : null));
-const tierList = computed<null | TierList>(() =>
-  rankingMode.value.type === "tierlist" ? rankingMode.value.tiers : null,
-);
-
-const rankIndex = computed(() => buildRankIndex(albumList.value));
+const description = computed(() => playlist.value.description);
+const { rankOf, tierList, topTiers } = useCollectionRanking(description, albumList);
 
 const topTierGroups = computed<[AlbumSimplified[], AlbumSimplified[], AlbumSimplified[]]>(() =>
   topTiers.value ? splitTopTiers(albumList.value, topTiers.value) : [[], [], []],
@@ -175,10 +135,6 @@ function errorMessage(err: unknown): string {
   if (err.response.status === 404) return "This collection doesn't exist.";
   if (err.response.status === 403) return "This collection is private. Ask the owner to make it public.";
   return "This collection is unavailable. Please try again later.";
-}
-
-function rankOf(id: string): number {
-  return (rankIndex.value.get(id) ?? -1) + 1;
 }
 
 onMounted(async () => {

--- a/src/views/playlist/SharedCollectionPage.vue
+++ b/src/views/playlist/SharedCollectionPage.vue
@@ -28,57 +28,43 @@
         <template v-if="topTiers">
           <div class="tier-section">
             <template v-for="(group, i) in topTierGroups" :key="i">
-              <template v-if="group.length">
-                <div class="tier-heading">{{ getTierLabel(i, topTiers) }}</div>
+              <TierRow v-if="group.length" :label="getTierLabel(i, topTiers)">
                 <div :class="['tier-grid', `tier-grid-${i}`]">
                   <SharedAlbumCard v-for="album in group" :key="album.id" :album="album" :rank="rankOf(album.id)" />
                 </div>
-              </template>
+              </TierRow>
             </template>
           </div>
         </template>
         <template v-else-if="tierList">
           <div class="tier-section">
             <template v-for="(tier, i) in tierList" :key="i">
-              <template v-if="tierGroups[i]?.length">
-                <div class="tier-row" :class="{ 'tier-row-side': configStore.tierListSideLabels }">
-                  <div
-                    class="tier-heading tier-heading-colored"
-                    :class="{ 'tier-heading-side': configStore.tierListSideLabels }"
-                    :style="{ backgroundColor: getTierColor(i, tierList.length) }"
-                  >
-                    {{ displayTierLabel(tier.label) }}
-                  </div>
-                  <div
-                    class="tier-grid"
-                    :class="configStore.tierListSideLabels ? 'tier-grid-side' : 'tier-grid-dynamic'"
-                  >
-                    <SharedAlbumCard v-for="album in tierGroups[i]" :key="album.id" :album="album" hover-metas />
-                  </div>
+              <TierRow
+                v-if="tierGroups[i]?.length"
+                :color="getTierColor(i, tierList.length)"
+                :label="displayTierLabel(tier.label)"
+                :side-layout="configStore.tierListSideLabels"
+              >
+                <div :class="configStore.tierListSideLabels ? 'tier-grid-side' : 'tier-grid-dynamic'" class="tier-grid">
+                  <SharedAlbumCard v-for="album in tierGroups[i]" :key="album.id" :album="album" hover-metas />
                 </div>
-              </template>
+              </TierRow>
             </template>
-            <template v-if="tierGroups[tierList.length]?.length">
-              <div class="tier-row" :class="{ 'tier-row-side': configStore.tierListSideLabels }">
-                <div
-                  class="tier-heading tier-heading-unsorted"
-                  :class="{ 'tier-heading-side': configStore.tierListSideLabels }"
-                >
-                  {{ UNSORTED_TIER_LABEL }}
-                </div>
-                <div
-                  class="tier-grid"
-                  :class="configStore.tierListSideLabels ? 'tier-grid-side' : 'tier-grid-dynamic'"
-                >
-                  <SharedAlbumCard
-                    v-for="album in tierGroups[tierList.length]"
-                    :key="album.id"
-                    :album="album"
-                    hover-metas
-                  />
-                </div>
+            <TierRow
+              v-if="tierGroups[tierList.length]?.length"
+              :label="UNSORTED_TIER_LABEL"
+              :side-layout="configStore.tierListSideLabels"
+              unsorted
+            >
+              <div :class="configStore.tierListSideLabels ? 'tier-grid-side' : 'tier-grid-dynamic'" class="tier-grid">
+                <SharedAlbumCard
+                  v-for="album in tierGroups[tierList.length]"
+                  :key="album.id"
+                  :album="album"
+                  hover-metas
+                />
               </div>
-            </template>
+            </TierRow>
           </div>
         </template>
         <div v-else class="album-list">
@@ -99,6 +85,7 @@ import { Paging } from "@/@types/Paging";
 import { Playlist, PlaylistTrack } from "@/@types/Playlist";
 import SharedAlbumCard from "@/components/album/SharedAlbumCard.vue";
 import { useConfig } from "@/components/config/ConfigStore";
+import TierRow from "@/components/playlist/TierRow.vue";
 import Cover from "@/components/ui/AlbumCover.vue";
 import ButtonIndex from "@/components/ui/ButtonIndex.vue";
 import Loader from "@/components/ui/LoadingDots.vue";
@@ -249,59 +236,6 @@ onMounted(async () => {
 
 .tier-section {
   padding-top: 1rem;
-}
-
-.tier-row {
-  display: contents;
-}
-
-.tier-row-side {
-  align-items: stretch;
-  display: flex;
-  margin-bottom: 1.5rem;
-}
-
-.tier-heading {
-  background-color: var(--bg-color);
-  border-radius: 0.4rem;
-  font-size: var(--font-size-lg);
-  line-break: anywhere;
-  margin: 2rem 0 1rem;
-  padding: 0.7rem 1.2rem;
-
-  @include font-bold;
-
-  &:first-child {
-    margin-top: 0;
-  }
-}
-
-.tier-heading-colored {
-  color: #fff;
-  text-shadow: 0 0.1rem 0.2rem rgb(0 0 0 / 40%);
-}
-
-.tier-heading-unsorted {
-  background-color: transparent;
-  border: 0.1rem dashed var(--bg-color-lighter);
-  color: var(--font-color-dark);
-  font-style: italic;
-  opacity: 0.7;
-}
-
-.tier-heading-side {
-  align-items: center;
-  border-radius: 0.4rem 0 0 0.4rem;
-  display: flex;
-  flex-shrink: 0;
-  justify-content: center;
-  margin: 0;
-  text-align: center;
-  width: 8rem;
-
-  @include responsive.mobile {
-    width: 5rem;
-  }
 }
 
 .tier-grid {

--- a/src/views/playlist/SharedCollectionPage.vue
+++ b/src/views/playlist/SharedCollectionPage.vue
@@ -27,14 +27,19 @@
         </header>
         <div class="album-list">
           <a
-            v-for="album in albumList"
+            v-for="(album, index) in albumList"
             :key="album.id"
+            :class="tierClassFor(index)"
             class="album"
+            :data-tier-label="tierLabelFor(index)"
             :href="album.external_urls.spotify"
             rel="noopener"
             target="_blank"
           >
-            <Cover :images="album.images" class="album-cover" size="medium" />
+            <div class="cover-wrap">
+              <div v-if="topTiers" class="rank-badge">{{ index + 1 }}</div>
+              <Cover :images="album.images" class="album-cover" size="medium" />
+            </div>
             <div class="name">{{ album.name }}</div>
             <div class="artists">{{ album.artists.map((a) => a.name).join(", ") }}</div>
           </a>
@@ -46,7 +51,7 @@
 
 <script lang="ts" setup>
 import { HTTPError } from "ky";
-import { onMounted, ref } from "vue";
+import { computed, onMounted, ref } from "vue";
 
 import { AlbumSimplified } from "@/@types/Album";
 import { defaultPlaylist } from "@/@types/Defaults";
@@ -57,6 +62,7 @@ import ButtonIndex from "@/components/ui/ButtonIndex.vue";
 import Loader from "@/components/ui/LoadingDots.vue";
 import PageFit from "@/components/ui/PageFit.vue";
 import PageScroller from "@/components/ui/PageScroller.vue";
+import { getTierForIndex, getTierLabel, parseTopTiers, TopTiers } from "@/helpers/collectionOptions";
 import { fetchAllPages } from "@/helpers/pagination";
 import { publicSpotifyGet } from "@/helpers/publicSpotify";
 import { removeDuplicatesAlbums } from "@/helpers/removeDuplicate";
@@ -69,12 +75,29 @@ const error = ref("");
 const playlist = ref<Playlist>(defaultPlaylist);
 const albumList = ref<AlbumSimplified[]>([]);
 const beardifyUrl = absoluteRouteUrl(RouteName.Collection, props.id);
+const topTiers = computed<null | TopTiers>(() => parseTopTiers(playlist.value.description));
 
 function errorMessage(err: unknown): string {
   if (!(err instanceof HTTPError)) return "This collection is unavailable. Please try again later.";
   if (err.response.status === 404) return "This collection doesn't exist.";
   if (err.response.status === 403) return "This collection is private. Ask the owner to make it public.";
   return "This collection is unavailable. Please try again later.";
+}
+
+function isTierStart(index: number): boolean {
+  if (!topTiers.value) return false;
+  if (index === 0) return true;
+  return getTierForIndex(index, topTiers.value) !== getTierForIndex(index - 1, topTiers.value);
+}
+
+function tierClassFor(index: number): string {
+  if (!topTiers.value) return "";
+  return `tier-${getTierForIndex(index, topTiers.value)}`;
+}
+
+function tierLabelFor(index: number): string | undefined {
+  if (!topTiers.value || !isTierStart(index)) return undefined;
+  return getTierLabel(getTierForIndex(index, topTiers.value), topTiers.value);
 }
 
 onMounted(async () => {
@@ -179,6 +202,7 @@ onMounted(async () => {
 .album-list {
   display: grid;
   gap: 2rem;
+  grid-auto-flow: dense;
   grid-template-columns: repeat(auto-fill, minmax(14rem, 1fr));
 
   @include responsive.mobile {
@@ -189,7 +213,51 @@ onMounted(async () => {
 
 .album {
   color: inherit;
+  position: relative;
   text-decoration: none;
+
+  &.tier-0 {
+    grid-column: span 2;
+    grid-row: span 2;
+  }
+
+  &.tier-2 {
+    transform: scale(0.85);
+    transform-origin: top left;
+  }
+
+  &[data-tier-label]::before {
+    content: attr(data-tier-label);
+    display: block;
+
+    @include font-bold;
+
+    font-size: var(--font-size-sm);
+    margin-bottom: 0.3rem;
+    opacity: 0.5;
+  }
+
+  .cover-wrap {
+    position: relative;
+  }
+
+  .rank-badge {
+    align-items: center;
+    background: var(--bg-color-darker);
+    border-radius: 100%;
+    box-shadow: 0 0.1rem 0.4rem rgb(0 0 0 / 40%);
+    display: flex;
+    font-size: var(--font-size-sm);
+    height: 2.2rem;
+    justify-content: center;
+    left: 0.5rem;
+    position: absolute;
+    top: 0.5rem;
+    width: 2.2rem;
+    z-index: 1;
+
+    @include font-bold;
+  }
 
   .album-cover {
     border-radius: 0.4rem;

--- a/src/views/playlist/SharedCollectionPage.vue
+++ b/src/views/playlist/SharedCollectionPage.vue
@@ -51,16 +51,38 @@
           <div class="tier-section">
             <template v-for="(tier, i) in tierList" :key="i">
               <template v-if="tierGroups[i]?.length">
-                <div
-                  class="tier-heading tier-heading-colored"
-                  :style="{ backgroundColor: getTierColor(i, tierList.length) }"
-                >
-                  {{ displayTierLabel(tier.label) }}
-                </div>
-                <div class="tier-grid tier-grid-dynamic">
-                  <SharedAlbumCard v-for="album in tierGroups[i]" :key="album.id" :album="album" />
+                <div class="tier-row" :class="{ 'tier-row-side': configStore.tierListSideLabels }">
+                  <div
+                    class="tier-heading tier-heading-colored"
+                    :class="{ 'tier-heading-side': configStore.tierListSideLabels }"
+                    :style="{ backgroundColor: getTierColor(i, tierList.length) }"
+                  >
+                    {{ displayTierLabel(tier.label) }}
+                  </div>
+                  <div
+                    class="tier-grid"
+                    :class="configStore.tierListSideLabels ? 'tier-grid-side' : 'tier-grid-dynamic'"
+                  >
+                    <SharedAlbumCard v-for="album in tierGroups[i]" :key="album.id" :album="album" />
+                  </div>
                 </div>
               </template>
+            </template>
+            <template v-if="unsortedGroup.length">
+              <div class="tier-row" :class="{ 'tier-row-side': configStore.tierListSideLabels }">
+                <div
+                  class="tier-heading tier-heading-unsorted"
+                  :class="{ 'tier-heading-side': configStore.tierListSideLabels }"
+                >
+                  {{ UNSORTED_TIER_LABEL }}
+                </div>
+                <div
+                  class="tier-grid"
+                  :class="configStore.tierListSideLabels ? 'tier-grid-side' : 'tier-grid-dynamic'"
+                >
+                  <SharedAlbumCard v-for="album in unsortedGroup" :key="album.id" :album="album" />
+                </div>
+              </div>
             </template>
           </div>
         </template>
@@ -81,6 +103,7 @@ import { defaultPlaylist } from "@/@types/Defaults";
 import { Paging } from "@/@types/Paging";
 import { Playlist, PlaylistTrack } from "@/@types/Playlist";
 import SharedAlbumCard from "@/components/album/SharedAlbumCard.vue";
+import { useConfig } from "@/components/config/ConfigStore";
 import Cover from "@/components/ui/AlbumCover.vue";
 import ButtonIndex from "@/components/ui/ButtonIndex.vue";
 import Loader from "@/components/ui/LoadingDots.vue";
@@ -93,6 +116,7 @@ import {
   parseCollectionRankingMode,
   TierList,
   TopTiers,
+  UNSORTED_TIER_LABEL,
 } from "@/helpers/collectionOptions";
 import { fetchAllPages } from "@/helpers/pagination";
 import { publicSpotifyGet } from "@/helpers/publicSpotify";
@@ -100,6 +124,7 @@ import { removeDuplicatesAlbums } from "@/helpers/removeDuplicate";
 import { absoluteRouteUrl, RouteName } from "@/router";
 
 const props = defineProps<{ id: string }>();
+const configStore = useConfig();
 
 const loading = ref(true);
 const error = ref("");
@@ -124,13 +149,19 @@ const tierGroups = computed<AlbumSimplified[][]>(() => {
   const list = tierList.value;
   if (!list) return [];
   let offset = 0;
-  return list.map((tier, index) => {
-    if (index === list.length - 1) return albumList.value.slice(offset);
+  return list.map((tier) => {
     const size = tier.size ?? 0;
     const group = albumList.value.slice(offset, offset + size);
     offset += size;
     return group;
   });
+});
+
+const unsortedGroup = computed<AlbumSimplified[]>(() => {
+  const list = tierList.value;
+  if (!list) return [];
+  const sortedCount = list.reduce((total, tier) => total + (tier.size ?? 0), 0);
+  return albumList.value.slice(sortedCount);
 });
 
 function errorMessage(err: unknown): string {
@@ -258,6 +289,16 @@ onMounted(async () => {
   padding-top: 1rem;
 }
 
+.tier-row {
+  display: contents;
+}
+
+.tier-row-side {
+  align-items: stretch;
+  display: flex;
+  margin-bottom: 1.5rem;
+}
+
 .tier-heading {
   background-color: var(--bg-color);
   border-radius: 0.4rem;
@@ -276,6 +317,30 @@ onMounted(async () => {
 .tier-heading-colored {
   color: #fff;
   text-shadow: 0 0.1rem 0.2rem rgb(0 0 0 / 40%);
+}
+
+.tier-heading-unsorted {
+  background-color: transparent;
+  border: 0.1rem dashed var(--bg-color-lighter);
+  color: var(--font-color-dark);
+  font-style: italic;
+  opacity: 0.7;
+}
+
+.tier-heading-side {
+  align-items: center;
+  border-radius: 0.4rem 0 0 0.4rem;
+  display: flex;
+  flex-shrink: 0;
+  justify-content: center;
+  line-break: anywhere;
+  margin: 0;
+  text-align: center;
+  width: 8rem;
+
+  @include responsive.mobile {
+    width: 5rem;
+  }
 }
 
 .tier-grid {
@@ -301,5 +366,22 @@ onMounted(async () => {
 
 .tier-grid-dynamic {
   grid-template-columns: repeat(auto-fill, minmax(10rem, 1fr));
+}
+
+.tier-grid-side {
+  background-color: var(--bg-color);
+  border-radius: 0 0.4rem 0.4rem 0;
+  display: flex;
+  flex-wrap: wrap;
+  padding: 1rem;
+
+  /* stylelint-disable-next-line selector-pseudo-class-no-unknown */
+  :deep(.album) {
+    width: 8rem;
+
+    @include responsive.mobile {
+      width: 6rem;
+    }
+  }
 }
 </style>

--- a/src/views/playlist/SharedCollectionPage.vue
+++ b/src/views/playlist/SharedCollectionPage.vue
@@ -78,7 +78,7 @@
                     class="tier-grid"
                     :class="configStore.tierListSideLabels ? 'tier-grid-side' : 'tier-grid-dynamic'"
                   >
-                    <SharedAlbumCard v-for="album in tierGroups[i]" :key="album.id" :album="album" />
+                    <SharedAlbumCard v-for="album in tierGroups[i]" :key="album.id" :album="album" hover-metas />
                   </div>
                 </div>
               </template>
@@ -95,7 +95,12 @@
                   class="tier-grid"
                   :class="configStore.tierListSideLabels ? 'tier-grid-side' : 'tier-grid-dynamic'"
                 >
-                  <SharedAlbumCard v-for="album in tierGroups[tierList.length]" :key="album.id" :album="album" />
+                  <SharedAlbumCard
+                    v-for="album in tierGroups[tierList.length]"
+                    :key="album.id"
+                    :album="album"
+                    hover-metas
+                  />
                 </div>
               </div>
             </template>

--- a/src/views/playlist/SharedCollectionPage.vue
+++ b/src/views/playlist/SharedCollectionPage.vue
@@ -27,22 +27,37 @@
         </header>
         <template v-if="topTiers">
           <div class="tier-section">
-            <template v-if="tier0.length">
+            <template v-if="topTierGroups[0].length">
               <div class="tier-heading">{{ getTierLabel(0, topTiers) }}</div>
               <div class="tier-grid tier-grid-0">
-                <SharedAlbumCard v-for="album in tier0" :key="album.id" :album="album" :rank="rankOf(album.id)" />
+                <SharedAlbumCard
+                  v-for="album in topTierGroups[0]"
+                  :key="album.id"
+                  :album="album"
+                  :rank="rankOf(album.id)"
+                />
               </div>
             </template>
-            <template v-if="tier1.length">
+            <template v-if="topTierGroups[1].length">
               <div class="tier-heading">{{ getTierLabel(1, topTiers) }}</div>
               <div class="tier-grid tier-grid-1">
-                <SharedAlbumCard v-for="album in tier1" :key="album.id" :album="album" :rank="rankOf(album.id)" />
+                <SharedAlbumCard
+                  v-for="album in topTierGroups[1]"
+                  :key="album.id"
+                  :album="album"
+                  :rank="rankOf(album.id)"
+                />
               </div>
             </template>
-            <template v-if="tier2.length">
+            <template v-if="topTierGroups[2].length">
               <div class="tier-heading">{{ getTierLabel(2, topTiers) }}</div>
               <div class="tier-grid tier-grid-2">
-                <SharedAlbumCard v-for="album in tier2" :key="album.id" :album="album" :rank="rankOf(album.id)" />
+                <SharedAlbumCard
+                  v-for="album in topTierGroups[2]"
+                  :key="album.id"
+                  :album="album"
+                  :rank="rankOf(album.id)"
+                />
               </div>
             </template>
           </div>
@@ -68,7 +83,7 @@
                 </div>
               </template>
             </template>
-            <template v-if="unsortedGroup.length">
+            <template v-if="tierGroups[tierList.length]?.length">
               <div class="tier-row" :class="{ 'tier-row-side': configStore.tierListSideLabels }">
                 <div
                   class="tier-heading tier-heading-unsorted"
@@ -80,7 +95,7 @@
                   class="tier-grid"
                   :class="configStore.tierListSideLabels ? 'tier-grid-side' : 'tier-grid-dynamic'"
                 >
-                  <SharedAlbumCard v-for="album in unsortedGroup" :key="album.id" :album="album" />
+                  <SharedAlbumCard v-for="album in tierGroups[tierList.length]" :key="album.id" :album="album" />
                 </div>
               </div>
             </template>
@@ -110,10 +125,13 @@ import Loader from "@/components/ui/LoadingDots.vue";
 import PageFit from "@/components/ui/PageFit.vue";
 import PageScroller from "@/components/ui/PageScroller.vue";
 import {
+  buildRankIndex,
   displayTierLabel,
   getTierColor,
   getTierLabel,
+  groupByTierList,
   parseCollectionRankingMode,
+  splitTopTiers,
   TierList,
   TopTiers,
   UNSORTED_TIER_LABEL,
@@ -137,32 +155,15 @@ const tierList = computed<null | TierList>(() =>
   rankingMode.value.type === "tierlist" ? rankingMode.value.tiers : null,
 );
 
-const tier0 = computed<AlbumSimplified[]>(() => (topTiers.value ? albumList.value.slice(0, topTiers.value[0]) : []));
-const tier1 = computed<AlbumSimplified[]>(() =>
-  topTiers.value ? albumList.value.slice(topTiers.value[0], topTiers.value[0] + topTiers.value[1]) : [],
-);
-const tier2 = computed<AlbumSimplified[]>(() =>
-  topTiers.value ? albumList.value.slice(topTiers.value[0] + topTiers.value[1]) : [],
+const rankIndex = computed(() => buildRankIndex(albumList.value));
+
+const topTierGroups = computed<[AlbumSimplified[], AlbumSimplified[], AlbumSimplified[]]>(() =>
+  topTiers.value ? splitTopTiers(albumList.value, topTiers.value) : [[], [], []],
 );
 
-const tierGroups = computed<AlbumSimplified[][]>(() => {
-  const list = tierList.value;
-  if (!list) return [];
-  let offset = 0;
-  return list.map((tier) => {
-    const size = tier.size ?? 0;
-    const group = albumList.value.slice(offset, offset + size);
-    offset += size;
-    return group;
-  });
-});
-
-const unsortedGroup = computed<AlbumSimplified[]>(() => {
-  const list = tierList.value;
-  if (!list) return [];
-  const sortedCount = list.reduce((total, tier) => total + (tier.size ?? 0), 0);
-  return albumList.value.slice(sortedCount);
-});
+const tierGroups = computed<AlbumSimplified[][]>(() =>
+  tierList.value ? groupByTierList(albumList.value, tierList.value) : [],
+);
 
 function errorMessage(err: unknown): string {
   if (!(err instanceof HTTPError)) return "This collection is unavailable. Please try again later.";
@@ -172,7 +173,7 @@ function errorMessage(err: unknown): string {
 }
 
 function rankOf(id: string): number {
-  return albumList.value.findIndex((album) => album.id === id) + 1;
+  return (rankIndex.value.get(id) ?? -1) + 1;
 }
 
 onMounted(async () => {

--- a/src/views/playlist/SharedCollectionPage.vue
+++ b/src/views/playlist/SharedCollectionPage.vue
@@ -303,12 +303,12 @@ onMounted(async () => {
 .tier-heading {
   background-color: var(--bg-color);
   border-radius: 0.4rem;
-
-  @include font-bold;
-
   font-size: var(--font-size-lg);
+  line-break: anywhere;
   margin: 2rem 0 1rem;
   padding: 0.7rem 1.2rem;
+
+  @include font-bold;
 
   &:first-child {
     margin-top: 0;
@@ -334,7 +334,6 @@ onMounted(async () => {
   display: flex;
   flex-shrink: 0;
   justify-content: center;
-  line-break: anywhere;
   margin: 0;
   text-align: center;
   width: 8rem;

--- a/src/views/playlist/SharedCollectionPage.vue
+++ b/src/views/playlist/SharedCollectionPage.vue
@@ -25,24 +25,30 @@
             </ButtonIndex>
           </div>
         </header>
-        <div class="album-list">
-          <a
-            v-for="(album, index) in albumList"
-            :key="album.id"
-            :class="tierClassFor(index)"
-            class="album"
-            :data-tier-label="tierLabelFor(index)"
-            :href="album.external_urls.spotify"
-            rel="noopener"
-            target="_blank"
-          >
-            <div class="cover-wrap">
-              <div v-if="topTiers" class="rank-badge">{{ index + 1 }}</div>
-              <Cover :images="album.images" class="album-cover" size="medium" />
-            </div>
-            <div class="name">{{ album.name }}</div>
-            <div class="artists">{{ album.artists.map((a) => a.name).join(", ") }}</div>
-          </a>
+        <template v-if="topTiers">
+          <div class="tier-section">
+            <template v-if="tier0.length">
+              <div class="tier-heading">{{ getTierLabel(0, topTiers) }}</div>
+              <div class="tier-grid tier-grid-0">
+                <SharedAlbumCard v-for="album in tier0" :key="album.id" :album="album" :rank="rankOf(album.id)" />
+              </div>
+            </template>
+            <template v-if="tier1.length">
+              <div class="tier-heading">{{ getTierLabel(1, topTiers) }}</div>
+              <div class="tier-grid tier-grid-1">
+                <SharedAlbumCard v-for="album in tier1" :key="album.id" :album="album" :rank="rankOf(album.id)" />
+              </div>
+            </template>
+            <template v-if="tier2.length">
+              <div class="tier-heading">{{ getTierLabel(2, topTiers) }}</div>
+              <div class="tier-grid tier-grid-2">
+                <SharedAlbumCard v-for="album in tier2" :key="album.id" :album="album" :rank="rankOf(album.id)" />
+              </div>
+            </template>
+          </div>
+        </template>
+        <div v-else class="album-list">
+          <SharedAlbumCard v-for="album in albumList" :key="album.id" :album="album" />
         </div>
       </div>
     </PageFit>
@@ -57,12 +63,13 @@ import { AlbumSimplified } from "@/@types/Album";
 import { defaultPlaylist } from "@/@types/Defaults";
 import { Paging } from "@/@types/Paging";
 import { Playlist, PlaylistTrack } from "@/@types/Playlist";
+import SharedAlbumCard from "@/components/album/SharedAlbumCard.vue";
 import Cover from "@/components/ui/AlbumCover.vue";
 import ButtonIndex from "@/components/ui/ButtonIndex.vue";
 import Loader from "@/components/ui/LoadingDots.vue";
 import PageFit from "@/components/ui/PageFit.vue";
 import PageScroller from "@/components/ui/PageScroller.vue";
-import { getTierForIndex, getTierLabel, parseTopTiers, TopTiers } from "@/helpers/collectionOptions";
+import { getTierLabel, parseTopTiers, TopTiers } from "@/helpers/collectionOptions";
 import { fetchAllPages } from "@/helpers/pagination";
 import { publicSpotifyGet } from "@/helpers/publicSpotify";
 import { removeDuplicatesAlbums } from "@/helpers/removeDuplicate";
@@ -77,6 +84,14 @@ const albumList = ref<AlbumSimplified[]>([]);
 const beardifyUrl = absoluteRouteUrl(RouteName.Collection, props.id);
 const topTiers = computed<null | TopTiers>(() => parseTopTiers(playlist.value.description));
 
+const tier0 = computed<AlbumSimplified[]>(() => (topTiers.value ? albumList.value.slice(0, topTiers.value[0]) : []));
+const tier1 = computed<AlbumSimplified[]>(() =>
+  topTiers.value ? albumList.value.slice(topTiers.value[0], topTiers.value[0] + topTiers.value[1]) : [],
+);
+const tier2 = computed<AlbumSimplified[]>(() =>
+  topTiers.value ? albumList.value.slice(topTiers.value[0] + topTiers.value[1]) : [],
+);
+
 function errorMessage(err: unknown): string {
   if (!(err instanceof HTTPError)) return "This collection is unavailable. Please try again later.";
   if (err.response.status === 404) return "This collection doesn't exist.";
@@ -84,20 +99,8 @@ function errorMessage(err: unknown): string {
   return "This collection is unavailable. Please try again later.";
 }
 
-function isTierStart(index: number): boolean {
-  if (!topTiers.value) return false;
-  if (index === 0) return true;
-  return getTierForIndex(index, topTiers.value) !== getTierForIndex(index - 1, topTiers.value);
-}
-
-function tierClassFor(index: number): string {
-  if (!topTiers.value) return "";
-  return `tier-${getTierForIndex(index, topTiers.value)}`;
-}
-
-function tierLabelFor(index: number): string | undefined {
-  if (!topTiers.value || !isTierStart(index)) return undefined;
-  return getTierLabel(getTierForIndex(index, topTiers.value), topTiers.value);
+function rankOf(id: string): number {
+  return albumList.value.findIndex((album) => album.id === id) + 1;
 }
 
 onMounted(async () => {
@@ -202,7 +205,6 @@ onMounted(async () => {
 .album-list {
   display: grid;
   gap: 2rem;
-  grid-auto-flow: dense;
   grid-template-columns: repeat(auto-fill, minmax(14rem, 1fr));
 
   @include responsive.mobile {
@@ -211,66 +213,44 @@ onMounted(async () => {
   }
 }
 
-.album {
-  color: inherit;
-  position: relative;
-  text-decoration: none;
+.tier-section {
+  padding-top: 1rem;
+}
 
-  &.tier-0 {
-    grid-column: span 2;
-    grid-row: span 2;
-  }
+.tier-heading {
+  background-color: var(--bg-color);
+  border-radius: 0.4rem;
 
-  &.tier-2 {
-    transform: scale(0.85);
-    transform-origin: top left;
-  }
+  @include font-bold;
 
-  &[data-tier-label]::before {
-    content: attr(data-tier-label);
-    display: block;
+  font-size: var(--font-size-lg);
+  margin: 2rem 0 1rem;
+  padding: 0.7rem 1.2rem;
 
-    @include font-bold;
-
-    font-size: var(--font-size-sm);
-    margin-bottom: 0.3rem;
-    opacity: 0.5;
-  }
-
-  .cover-wrap {
-    position: relative;
-  }
-
-  .rank-badge {
-    align-items: center;
-    background: var(--bg-color-darker);
-    border-radius: 100%;
-    box-shadow: 0 0.1rem 0.4rem rgb(0 0 0 / 40%);
-    display: flex;
-    font-size: var(--font-size-sm);
-    height: 2.2rem;
-    justify-content: center;
-    left: 0.5rem;
-    position: absolute;
-    top: 0.5rem;
-    width: 2.2rem;
-    z-index: 1;
-
-    @include font-bold;
-  }
-
-  .album-cover {
-    border-radius: 0.4rem;
-    margin-bottom: 0.5rem;
-    width: 100%;
-  }
-
-  .name {
-    @include font-bold;
-  }
-
-  .artists {
-    opacity: 0.6;
+  &:first-child {
+    margin-top: 0;
   }
 }
+
+.tier-grid {
+  display: grid;
+  gap: 2rem;
+
+  @include responsive.mobile {
+    gap: 1rem;
+  }
+}
+
+.tier-grid-0 {
+  grid-template-columns: repeat(auto-fill, minmax(15rem, 1fr));
+}
+
+.tier-grid-1 {
+  grid-template-columns: repeat(auto-fill, minmax(10rem, 1fr));
+}
+
+.tier-grid-2 {
+  grid-template-columns: repeat(auto-fill, minmax(7rem, 1fr));
+}
+
 </style>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -69,5 +69,11 @@ export default defineConfig({
     },
     host: "127.0.0.1",
     port: 3000,
+    proxy: {
+      "/.netlify/functions": {
+        changeOrigin: true,
+        target: "http://localhost:9999",
+      },
+    },
   },
 });


### PR DESCRIPTION
Tags were parsed from the playlist name, which forced ugly titles and gave no room for extra options. Both #Collection and the ranking mode now live in the playlist description instead, clean and public via the read-only /share page (no backend to store this elsewhere).

## Ranking modes

Two mutually exclusive, independently encoded modes (`#Top:x-y-z` / `#Tier:label=size,...`) — never silently converted into one another:

- **Top** (unchanged, fixed 3-tier count-based ranking): presets (Top 20/50/100), rank badges, per-index tier lookup.
- **Tier list** (new): free-form custom categories, arbitrary count, drag-managed sizes. New albums land in a separate, non-editable "Unsorted" bucket instead of silently joining an existing category. Tier headings get a red→green color gradient; a "Side labels" option (default on, toggle in settings) lays out categories tierlist.com-style instead of a heading-above-grid.

## Supporting changes

- `collectionOptions.ts`: parse/build tags, tier presets, shared tier-grouping helpers (`groupByTierList`, `splitTopTiers`, `buildRankIndex`) reused by both the editable and read-only pages
- CollectionPage/SharedCollectionPage render ranked albums in tiers, reusing the existing drag-reorder logic; drag and delete keep stored tier sizes in sync with reality (position-derived membership needs this, since there's no per-item ID storage — the 300-char description budget doesn't allow it)
- EditPlaylist/AddCollection get a Ranking mode picker (Off/Top/Tier list) for owners
- header button + PlaylistStore action to migrate playlists still using the old name-based tag
- sidebar TOP/TIER badges for collections with ranking enabled
- decode HTML entities Spotify encodes into descriptions (e.g. apostrophes as `&#x27;`) so custom labels display correctly
- grab/grabbing cursor over draggable albums