### PR TITLE
refactor(api): add AbortController to external requests

### DIFF
--- a/src/helpers/discogs.ts
+++ b/src/helpers/discogs.ts
@@ -51,10 +51,14 @@ const discogsClient = ky.create({
 /**
  * Get artist data from Discogs
  * @param discogsId - The Discogs ID of the artist
+ * @param signal - Aborts the request when the caller moves on (e.g. artist navigation)
  * @returns Promise resolving to the full DiscogsArtist object or null
  */
-export async function getDiscogsArtist(discogsId: string): Promise<DiscogsArtist | null> {
-  return fetchFromDiscogs<DiscogsArtist>(`artists/${discogsId}`);
+export async function getDiscogsArtist(
+  discogsId: string,
+  signal?: AbortSignal,
+): Promise<DiscogsArtist | null> {
+  return fetchFromDiscogs<DiscogsArtist>(`artists/${discogsId}`, undefined, signal);
 }
 
 /**
@@ -66,20 +70,21 @@ const memberInfoCache = new Map<string, MemberInfo | null>();
  * Get artist releases from Discogs
  * @param discogsId - The Discogs ID of the artist
  * @param page - Page number (default: 1)
- * @param perPage - Results per page (default: 100, max: 100)
+ * @param signal - Aborts the request when the caller moves on (e.g. artist navigation)
  * @returns Promise resolving to DiscogsArtistReleasesResponse or null
  */
 export async function getDiscogsArtistReleases(
   discogsId: string,
   page = 1,
-  perPage = 100,
+  signal?: AbortSignal,
 ): Promise<DiscogsArtistReleasesResponse | null> {
   return fetchFromDiscogs<DiscogsArtistReleasesResponse>(`artists/${discogsId}/releases`, {
     page: page.toString(),
-    per_page: perPage.toString(),
+    // 100 is both the Discogs maximum and the only value this app ever wants
+    per_page: "100",
     sort: "year",
     sort_order: "desc",
-  });
+  }, signal);
 }
 
 /**
@@ -284,7 +289,11 @@ const HTML_ENTITIES: Record<string, string> = {
  * @param searchParams - Query parameters
  * @returns Promise resolving to the requested data type or null
  */
-async function fetchFromDiscogs<T>(path: string, searchParams?: Record<string, string>): Promise<null | T> {
+async function fetchFromDiscogs<T>(
+  path: string,
+  searchParams?: Record<string, string>,
+  signal?: AbortSignal,
+): Promise<null | T> {
   if (!DISCOGS_TOKEN) {
     return null;
   }
@@ -292,6 +301,7 @@ async function fetchFromDiscogs<T>(path: string, searchParams?: Record<string, s
   try {
     const response = await discogsClient.get(path, {
       searchParams: { ...searchParams, token: DISCOGS_TOKEN },
+      signal,
     });
     return await response.json<T>();
   } catch {

--- a/src/helpers/musicbrainz.ts
+++ b/src/helpers/musicbrainz.ts
@@ -132,12 +132,23 @@ interface MusicBrainzUrlLookup {
  */
 const musicbrainzClient = ky.create({
   baseUrl: MUSICBRAINZ_API_URL,
-  retry: {
-    limit: 1,
-    statusCodes: [429, 503],
-  },
+  // No client retry: ky retries inside the already-granted queue slot, unpaced, so a 429/503
+  // was re-fired within the very second the queue exists to protect. The queue below is the
+  // single owner of rate-limit policy; a failed request returns null and the caller moves on.
+  retry: { limit: 0 },
   timeout: 10000,
 });
+
+/**
+ * MusicBrainz allows ~1 request/s per IP for anonymous clients and answers 503 as soon as
+ * the rate is exceeded. Callers otherwise fire concurrently — artist search, id lookup and
+ * the paginated release-group browse all overlap, and a fast artist-to-artist navigation
+ * stacks several such chains — so every request goes through one queue that serializes and
+ * spaces them instead of each caller racing the limit on its own.
+ */
+const MIN_REQUEST_INTERVAL_MS = 1100;
+let requestQueue: Promise<unknown> = Promise.resolve();
+let lastRequestAt = 0;
 
 /**
  * Build a map of normalized base title (before subtitle separator) -> type.
@@ -294,39 +305,40 @@ export function extractExternalIds(artistFull: MusicBrainzArtist): {
 /**
  * Get Discogs ID, Wikidata ID and band members from MusicBrainz artist
  * @param musicbrainzId - The MusicBrainz ID of the artist
+ * @param signal - Aborts the request when the caller moves on (e.g. artist navigation)
  * @returns Promise resolving to the MusicBrainzArtist object with relations, or null
  */
 export async function getIdsFromMusicBrainz(
   musicbrainzId: string,
+  signal?: AbortSignal,
 ): Promise<MusicBrainzArtist | null> {
   return fetchFromMusicBrainz<MusicBrainzArtist>(`artist/${musicbrainzId}`, {
     inc: "artist-rels+url-rels",
-  });
+  }, signal);
 }
 
 /**
  * Browse all release-groups of a MusicBrainz artist (paginated, 100 per page).
  * @param musicbrainzId - The MusicBrainz ID of the artist
+ * @param signal - Aborts the request when the caller moves on (e.g. artist navigation)
  * @returns Promise resolving to every release-group, or an empty array on failure
  */
 export async function getMusicBrainzReleaseGroups(
   musicbrainzId: string,
+  signal?: AbortSignal,
 ): Promise<MusicBrainzReleaseGroup[]> {
   const PAGE_SIZE = 100;
-  // MB anonymous rate limit is ~1 req/s. Wait between pages to avoid 429s that
-  // would cause fetchFromMusicBrainz to return null and break the loop early.
-  const PAGE_DELAY_MS = 600;
   const all: MusicBrainzReleaseGroup[] = [];
   let offset = 0;
 
   for (;;) {
-    if (offset > 0) await sleep(PAGE_DELAY_MS);
-
+    // Page spacing and abort handling both live in the shared request queue: an aborted
+    // browse gets null back immediately and falls out through the check below.
     const data = await fetchFromMusicBrainz<MusicBrainzReleaseGroupBrowse>("release-group", {
       artist: musicbrainzId,
       limit: PAGE_SIZE,
       offset,
-    });
+    }, signal);
 
     // null means a fetch/network error — stop, don't confuse with an empty last page.
     if (data === null) break;
@@ -345,15 +357,17 @@ export async function getMusicBrainzReleaseGroups(
 /**
  * Search for artists by name in MusicBrainz
  * @param artistName - The name of the artist to search for
+ * @param signal - Aborts the request when the caller moves on (e.g. artist navigation)
  * @returns Promise resolving to all matching MusicBrainzArtist with the same name, or empty array
  */
 export async function searchMusicBrainzArtistId(
   artistName: string,
+  signal?: AbortSignal,
 ): Promise<MusicBrainzArtist[]> {
   const data = await fetchFromMusicBrainz<MusicBrainzArtistSearch>("artist", {
     limit: 10,
     query: `artist:"${artistName}"`,
-  });
+  }, signal);
 
   if (data && data.artists && data.artists.length > 0) {
     const normalizedSearchName = normalizeName(artistName);
@@ -369,15 +383,17 @@ export async function searchMusicBrainzArtistId(
  * Search for an artist by Spotify ID via MusicBrainz URL lookup.
  * This avoids homonym issues by matching the exact Spotify URL relationship.
  * @param spotifyId - The Spotify artist ID
+ * @param signal - Aborts the request when the caller moves on (e.g. artist navigation)
  * @returns Promise resolving to the MusicBrainzArtist or null
  */
 export async function searchMusicBrainzBySpotifyId(
   spotifyId: string,
+  signal?: AbortSignal,
 ): Promise<MusicBrainzArtist | null> {
   const data = await fetchFromMusicBrainz<MusicBrainzUrlLookup>("url", {
     inc: "artist-rels",
     resource: `https://open.spotify.com/artist/${spotifyId}`,
-  });
+  }, signal);
 
   if (data?.relations?.length) {
     const artistRel = data.relations.find(
@@ -390,6 +406,29 @@ export async function searchMusicBrainzBySpotifyId(
 }
 
 /**
+ * Run a MusicBrainz request once the queue reaches it and the spacing has elapsed.
+ * @param task - The request to run
+ * @param signal - Skips the slot entirely when the caller has already moved on
+ */
+function enqueue<T>(task: () => Promise<T>, signal?: AbortSignal): Promise<null | T> {
+  const scheduled = requestQueue.then(async (): Promise<null | T> => {
+    // Checked before waiting: an abandoned request must not hold the queue for a second.
+    if (signal?.aborted) return null;
+
+    const wait = lastRequestAt + MIN_REQUEST_INTERVAL_MS - Date.now();
+    if (wait > 0) await sleep(wait);
+    if (signal?.aborted) return null;
+
+    lastRequestAt = Date.now();
+    return task();
+  });
+
+  // The chain must survive a failed request, otherwise one rejection blocks every later one.
+  requestQueue = scheduled.then(() => undefined, () => undefined);
+  return scheduled;
+}
+
+/**
  * Generic fetch function for MusicBrainz API
  * @param path - API endpoint path
  * @param searchParams - Query parameters
@@ -398,16 +437,20 @@ export async function searchMusicBrainzBySpotifyId(
 async function fetchFromMusicBrainz<T>(
   path: string,
   searchParams: Record<string, number | string> = {},
+  signal?: AbortSignal,
 ): Promise<null | T> {
   try {
-    const response = await musicbrainzClient.get(path, {
-      searchParams: {
-        fmt: "json",
-        ...searchParams,
-      },
-    });
+    return await enqueue(async () => {
+      const response = await musicbrainzClient.get(path, {
+        searchParams: {
+          fmt: "json",
+          ...searchParams,
+        },
+        signal,
+      });
 
-    return await response.json<T>();
+      return await response.json<T>();
+    }, signal);
   } catch {
     return null;
   }

--- a/src/helpers/wikidata.ts
+++ b/src/helpers/wikidata.ts
@@ -336,16 +336,31 @@ const wikidataClient = http.extend({
 });
 
 /**
+ * Entity requests currently in flight, keyed by entity id.
+ *
+ * `getWikidataArtist` and `getWikidataBandMembers` are called together for the same band and
+ * read the same document, which Wikidata serves as `must-revalidate, max-age=0` — so without
+ * this the payload (several hundred KB for a large band) is downloaded and parsed twice on
+ * every artist page. Entries clear as soon as the request settles: this shares concurrent
+ * callers, it is not a cache. Callers are expected to share one abort signal, since the first
+ * one's signal is the one the shared request carries.
+ */
+const inFlightEntities = new Map<string, Promise<Record<string, WikidataEntity>>>();
+
+/**
  * Get artist data from Wikidata by entity ID
  * @param entityId - The Wikidata entity ID (e.g., Q483)
+ * @param signal - Aborts the request when the caller moves on (e.g. artist navigation)
  * @returns Promise resolving to WikidataArtist or null
  */
-export async function getWikidataArtist(entityId: string): Promise<null | WikidataArtist> {
+export async function getWikidataArtist(
+  entityId: string,
+  signal?: AbortSignal,
+): Promise<null | WikidataArtist> {
   try {
-    const response = await wikidataClient.get(`${WIKIDATA_ENTITY_URL}${entityId}.json`);
-    const data = await response.json<{ entities: Record<string, WikidataEntity> }>();
+    const entities = await fetchWikidataEntities(entityId, signal);
 
-    const entity = data.entities[entityId];
+    const entity = entities[entityId];
     if (!entity) {
       return null;
     }
@@ -362,13 +377,16 @@ export async function getWikidataArtist(entityId: string): Promise<null | Wikida
  * start/end time qualifiers. Member names and instruments are resolved
  * through batched wbgetentities calls (no WDQS / SPARQL dependency).
  * @param entityId - The Wikidata entity ID of the band (e.g., Q15920)
+ * @param signal - Aborts the requests when the caller moves on (e.g. artist navigation)
  * @returns Promise resolving to band members, empty array when none
  */
-export async function getWikidataBandMembers(entityId: string): Promise<BandMember[]> {
+export async function getWikidataBandMembers(
+  entityId: string,
+  signal?: AbortSignal,
+): Promise<BandMember[]> {
   try {
-    const response = await wikidataClient.get(`${WIKIDATA_ENTITY_URL}${entityId}.json`);
-    const data = await response.json<{ entities: Record<string, WikidataEntity> }>();
-    const statements = data.entities[entityId]?.claims?.[MEMBER_PROPERTIES.HAS_PART];
+    const entities = await fetchWikidataEntities(entityId, signal);
+    const statements = entities[entityId]?.claims?.[MEMBER_PROPERTIES.HAS_PART];
     if (!statements?.length) return [];
 
     // Extract member Q-ids and their start/end periods from the statements
@@ -390,6 +408,7 @@ export async function getWikidataBandMembers(entityId: string): Promise<BandMemb
     const memberEntities = await getWikidataEntities(
       partials.map((part) => part.id),
       "labels|claims",
+      signal,
     );
 
     const instrumentIds = new Set<string>();
@@ -413,7 +432,7 @@ export async function getWikidataBandMembers(entityId: string): Promise<BandMemb
     if (enriched.length === 0) return [];
 
     // Resolve instrument labels in a second batch
-    const instrumentLabels = await getWikidataEntities([...instrumentIds], "labels");
+    const instrumentLabels = await getWikidataEntities([...instrumentIds], "labels", signal);
 
     return enriched.map((member) => ({
       begin: member.begin,
@@ -433,9 +452,13 @@ export async function getWikidataBandMembers(entityId: string): Promise<BandMemb
 /**
  * Get Wikipedia article content (extract) from a Wikipedia URL
  * @param wikipediaUrl - The full Wikipedia URL
+ * @param signal - Aborts the request when the caller moves on (e.g. artist navigation)
  * @returns Promise resolving to the article extract HTML or null
  */
-export async function getWikipediaExtract(wikipediaUrl: string): Promise<null | string> {
+export async function getWikipediaExtract(
+  wikipediaUrl: string,
+  signal?: AbortSignal,
+): Promise<null | string> {
   try {
     // Extract language and title from URL
     // e.g., "https://en.wikipedia.org/wiki/Radiohead" -> lang: "en", title: "Radiohead"
@@ -456,7 +479,7 @@ export async function getWikipediaExtract(wikipediaUrl: string): Promise<null | 
       titles: title,
     });
 
-    const response = await http.get(`https://${lang}.wikipedia.org/w/api.php?${params.toString()}`);
+    const response = await http.get(`https://${lang}.wikipedia.org/w/api.php?${params.toString()}`, { signal });
     const data = (await response.json()) as {
       query?: {
         pages: Record<
@@ -545,6 +568,28 @@ function cleanWikipediaHtml(html: string): string {
 }
 
 /**
+ * Fetch a Wikidata entity document, joining a request already in flight for the same id.
+ * @param entityId - The Wikidata entity ID (e.g., Q483)
+ * @param signal - Aborts the request when the caller moves on (e.g. artist navigation)
+ */
+function fetchWikidataEntities(
+  entityId: string,
+  signal?: AbortSignal,
+): Promise<Record<string, WikidataEntity>> {
+  const pending = inFlightEntities.get(entityId);
+  if (pending) return pending;
+
+  const request = wikidataClient
+    .get(`${WIKIDATA_ENTITY_URL}${entityId}.json`, { signal })
+    .json<{ entities: Record<string, WikidataEntity> }>()
+    .then((data) => data.entities)
+    .finally(() => inFlightEntities.delete(entityId));
+
+  inFlightEntities.set(entityId, request);
+  return request;
+}
+
+/**
  * Extract all entity Q-ids referenced by a given property on an entity
  */
 function getClaimEntityIds(entity: WikidataEntity, property: string): string[] {
@@ -594,14 +639,17 @@ function getSnakEntityId(snak: WikidataSnak): null | string {
  * Batch-resolve Wikidata entities via wbgetentities (max 50 ids per request)
  * @param ids - Entity Q-ids to resolve
  * @param props - Comma-separated props (e.g. "labels|claims")
+ * @param signal - Aborts the requests when the caller moves on (e.g. artist navigation)
  */
 async function getWikidataEntities(
   ids: string[],
   props: string,
+  signal?: AbortSignal,
 ): Promise<Record<string, WikidataEntity>> {
   const result: Record<string, WikidataEntity> = {};
 
   for (let i = 0; i < ids.length; i += WBGETENTITIES_CHUNK) {
+    if (signal?.aborted) break;
     const chunk = ids.slice(i, i + WBGETENTITIES_CHUNK);
     if (chunk.length === 0) continue;
 
@@ -614,7 +662,7 @@ async function getWikidataEntities(
       props,
     });
 
-    const response = await wikidataClient.get(`${WIKIDATA_API_URL}?${params.toString()}`);
+    const response = await wikidataClient.get(`${WIKIDATA_API_URL}?${params.toString()}`, { signal });
     const data = await response.json<{ entities?: Record<string, WikidataEntity> }>();
     if (data.entities) Object.assign(result, data.entities);
   }

--- a/src/helpers/wikipediaTimeline.ts
+++ b/src/helpers/wikipediaTimeline.ts
@@ -96,9 +96,13 @@ const MAIN_ARTICLE_TEMPLATES = [
 /**
  * Fetch and parse a Wikipedia band article's EasyTimeline members graph.
  * @param wikipediaUrl - Full Wikipedia URL (any language; English usually has the graph)
+ * @param signal - Aborts the requests when the caller moves on (e.g. artist navigation)
  * @returns The parsed timeline, or null when the article has no timeline block
  */
-export async function getWikipediaTimeline(wikipediaUrl: string): Promise<null | WikiTimeline> {
+export async function getWikipediaTimeline(
+  wikipediaUrl: string,
+  signal?: AbortSignal,
+): Promise<null | WikiTimeline> {
   try {
     const urlMatch = wikipediaUrl.match(/https?:\/\/(\w+)\.wikipedia\.org\/wiki\/(.+)/);
     if (!urlMatch) return null;
@@ -106,7 +110,7 @@ export async function getWikipediaTimeline(wikipediaUrl: string): Promise<null |
     const [, lang, encodedTitle] = urlMatch;
     const title = decodeURIComponent(encodedTitle);
 
-    const wikitext = await fetchWikitext(lang, title);
+    const wikitext = await fetchWikitext(lang, title, signal);
     if (!wikitext) return null;
 
     const ownBlock = extractTimelineBlock(wikitext);
@@ -118,7 +122,7 @@ export async function getWikipediaTimeline(wikipediaUrl: string): Promise<null |
     // article only links to it and lists a short (often incomplete) members summary. Prefer it.
     const dedicatedTitle = findDedicatedMembersPage(wikitext);
     if (dedicatedTitle) {
-      const dedicatedWikitext = await fetchWikitext(lang, dedicatedTitle);
+      const dedicatedWikitext = await fetchWikitext(lang, dedicatedTitle, signal);
       const dedicatedResult = dedicatedWikitext ? parseWikitextTimeline(dedicatedWikitext) : null;
       if (dedicatedResult) return dedicatedResult;
     }
@@ -159,7 +163,7 @@ function extractTimelineBlock(wikitext: string): null | string {
 }
 
 /** Fetch a Wikipedia article's raw wikitext via the parse API. */
-async function fetchWikitext(lang: string, title: string): Promise<null | string> {
+async function fetchWikitext(lang: string, title: string, signal?: AbortSignal): Promise<null | string> {
   const params = new URLSearchParams({
     action: "parse",
     format: "json",
@@ -169,7 +173,7 @@ async function fetchWikitext(lang: string, title: string): Promise<null | string
     prop: "wikitext",
   });
 
-  const response = await http.get(`https://${lang}.wikipedia.org/w/api.php?${params.toString()}`);
+  const response = await http.get(`https://${lang}.wikipedia.org/w/api.php?${params.toString()}`, { signal });
   const data = await response.json<{ parse?: { wikitext?: string } }>();
   return data.parse?.wikitext ?? null;
 }
@@ -211,8 +215,7 @@ function parseAttrs(line: string): Record<string, string> {
   const re = /(\w+):("[^"]*"|\S+)/g;
   let match: null | RegExpExecArray;
   while ((match = re.exec(line)) !== null) {
-    const key = match[1].toLowerCase();
-    if (!(key in attrs)) attrs[key] = match[2].replace(/^"|"$/g, "");
+    attrs[match[1].toLowerCase()] = match[2].replace(/^"|"$/g, "");
   }
   return attrs;
 }
@@ -337,7 +340,7 @@ function parseEasyTimeline(block: string): null | WikiTimeline {
   const events: WikiTimelineEvent[] = [];
   // Raw widths kept aside: "thin" is relative to the widest plotted bar, which the DSL
   // only makes known once every line has been read.
-  const plotted: { seg: WikiTimelineSegment; width: number }[] = [];
+  const plotted: { seg: Omit<WikiTimelineSegment, "thin">; width: number }[] = [];
 
   // EasyTimeline is stateful: inside PlotData / LineData a line carrying only `color:` or
   // `width:` sets the default for every following entry that omits them.
@@ -400,7 +403,6 @@ function parseEasyTimeline(block: string): null | WikiTimeline {
         colorId,
         from: fromYear,
         openEnded: attrs.till === "end" || attrs.till.includes("#time"),
-        thin: false,
         till: tillYear,
       },
       width: attrs.width ? parseInt(attrs.width, 10) : defaultWidth,

--- a/src/views/artist/ArtistStore.ts
+++ b/src/views/artist/ArtistStore.ts
@@ -27,7 +27,7 @@ import { notification } from "@/helpers/notifications";
 import { removeDuplicatesAlbums } from "@/helpers/removeDuplicate";
 import { cleanUrl } from "@/helpers/urls";
 import { isEP, useCheckCompilationAlbum, useCheckLiveAlbum } from "@/helpers/useCleanAlbums";
-import { getWikipediaExtract } from "@/helpers/wikidata";
+import { getWikidataArtist, getWikidataBandMembers, getWikipediaExtract } from "@/helpers/wikidata";
 
 interface DiscographySnapshot {
   albums: AlbumSimplified[];
@@ -44,6 +44,20 @@ interface DiscographySnapshot {
 const CACHE_TTL_MS = 5 * 60 * 1000;
 const CACHE_MAX_ENTRIES = 10;
 const discographyCache = new Map<string, DiscographySnapshot>();
+
+/**
+ * Replaced (after `abort()`) by `clean()`, i.e. once per artist-page navigation.
+ *
+ * The external sources (MusicBrainz, Wikidata, Wikipedia, Discogs) are slow and
+ * rate-limited, so a response for the previous artist routinely lands after the next
+ * page has started loading. Aborting cuts those requests in flight — MusicBrainz allows
+ * ~1 req/s per IP, and a stale paginated browse otherwise eats the new artist's budget.
+ *
+ * Each action captures the signal on entry, hands it to its fetches, and re-checks
+ * `signal.aborted` after every await: a promise that already resolved still runs its
+ * continuation, so aborting alone does not prevent a stale write.
+ */
+let navigationController = new AbortController();
 
 interface ReleaseLookupMaps {
   baseTitles: Map<string, string>;
@@ -136,6 +150,8 @@ function lookupReleaseType(
 export const useArtist = defineStore("artist", {
   actions: {
     async clean() {
+      navigationController.abort();
+      navigationController = new AbortController();
       this.activeTab = "discography";
       this.artist = defaultArtist;
       this.bandMembers = [];
@@ -161,10 +177,12 @@ export const useArtist = defineStore("artist", {
     },
 
     async getAlbums(url: string) {
+      const { signal } = navigationController;
       try {
         const cleanedUrl = cleanUrl(url);
         const { data }
-          = await instance().get<Paging<AlbumSimplified>>(cleanedUrl);
+          = await instance().get<Paging<AlbumSimplified>>(cleanedUrl, { signal });
+        if (signal.aborted) return;
 
         const frenchMarketAlbums = data.items.filter((album) =>
           album.available_markets.includes("FR"),
@@ -199,27 +217,37 @@ export const useArtist = defineStore("artist", {
     },
 
     async getArtist(artistId: string) {
+      const { signal } = navigationController;
       try {
-        const { data } = await instance().get<Artist>(`artists/${artistId}`);
+        const { data } = await instance().get<Artist>(`artists/${artistId}`, { signal });
+        if (signal.aborted) return;
         this.artist = data;
 
-        // Fetch external IDs and data (Spotify ID used for exact MusicBrainz match)
+        // Fetch external IDs and data (Spotify ID used for exact MusicBrainz match).
+        // `getIds` starts the Wikidata chain itself, as soon as the id is known.
         await this.getIds(data.name, data.id);
+        if (signal.aborted) return;
 
-        if (this.wikidataId) {
-          this.getWikidataArtist(this.wikidataId);
-        }
+        // Single owner of the info-tab spinner: `getWikidataArtist` clears it in its own
+        // `finally` — so a Wikidata id means it is already running and owns the flag. Every
+        // other outcome (no Wikidata id, no MusicBrainz match, request failure) clears it
+        // here, otherwise the loader spins forever.
+        if (!this.wikidataId) this.timelineLoading = false;
       } catch {
+        if (signal.aborted) return;
         this.artist = defaultArtist;
+        this.timelineLoading = false;
         notification({ msg: "Unable to load this artist.", type: NotificationType.Error });
       }
     },
 
     async getCompilations(url: string) {
+      const { signal } = navigationController;
       try {
         const cleanedUrl = cleanUrl(url);
         const { data }
-          = await instance().get<Paging<AlbumSimplified>>(cleanedUrl);
+          = await instance().get<Paging<AlbumSimplified>>(cleanedUrl, { signal });
+        if (signal.aborted) return;
 
         const frenchMarketAlbums = data.items.filter((album) =>
           album.available_markets.includes("FR"),
@@ -247,31 +275,36 @@ export const useArtist = defineStore("artist", {
     },
 
     async getDiscogsArtist(discogsId: string) {
+      const { signal } = navigationController;
       try {
-        const artist = await getDiscogsArtist(discogsId);
+        const artist = await getDiscogsArtist(discogsId, signal);
+        if (signal.aborted) return;
         this.discogsArtist = artist;
 
         if (artist) {
           await this.getDiscogsReleases(discogsId);
         }
       } catch {
-        this.discogsArtist = null;
+        if (!signal.aborted) this.discogsArtist = null;
       }
     },
 
     async getDiscogsReleases(discogsId: string) {
+      const { signal } = navigationController;
       try {
-        const firstPage = await getDiscogsArtistReleases(discogsId);
-        if (!firstPage) return;
+        const firstPage = await getDiscogsArtistReleases(discogsId, 1, signal);
+        if (!firstPage || signal.aborted) return;
 
         const allReleases = [...firstPage.releases];
 
         // Fetch a second page if available (200 releases total) so older albums
         // — whose release entries are sorted by year desc — are also covered.
         if (firstPage.pagination.pages > 1) {
-          const secondPage = await getDiscogsArtistReleases(discogsId, 2);
+          const secondPage = await getDiscogsArtistReleases(discogsId, 2, signal);
           if (secondPage?.releases) allReleases.push(...secondPage.releases);
         }
+
+        if (signal.aborted) return;
 
         // MusicBrainz is the primary source and must win, so Discogs only fills
         // in keys MusicBrainz didn't provide (existing entries take precedence).
@@ -286,14 +319,17 @@ export const useArtist = defineStore("artist", {
     },
 
     async getFollowStatus(artistId: string) {
+      const { signal } = navigationController;
       try {
-        this.followStatus = await isInLibrary("artist", artistId);
+        const status = await isInLibrary("artist", artistId);
+        if (!signal.aborted) this.followStatus = status;
       } catch {
         // silent fail
       }
     },
 
     async getIds(artistName: string, spotifyId?: string) {
+      const { signal } = navigationController;
       this.musicbrainzArtist = null;
       this.bandMembers = [];
       this.discogsId = null;
@@ -303,18 +339,18 @@ export const useArtist = defineStore("artist", {
       try {
         // Search by name first; if multiple homonyms found and Spotify ID available,
         // use Spotify URL lookup for exact match
-        const nameResults = await searchMusicBrainzArtistId(artistName);
+        const nameResults = await searchMusicBrainzArtistId(artistName, signal);
         const artist
           = nameResults.length === 1
             ? nameResults[0]
             : nameResults.length > 1 && spotifyId
-              ? ((await searchMusicBrainzBySpotifyId(spotifyId)) ?? nameResults[0])
+              ? ((await searchMusicBrainzBySpotifyId(spotifyId, signal)) ?? nameResults[0])
               : nameResults[0] ?? null;
 
         if (!artist?.id) return;
 
-        const artistFull = await getIdsFromMusicBrainz(artist.id);
-        if (!artistFull) return;
+        const artistFull = await getIdsFromMusicBrainz(artist.id, signal);
+        if (!artistFull || signal.aborted) return;
 
         this.musicbrainzArtist = { ...artist, ...artistFull };
         this.bandMembers = extractBandMembers(artistFull);
@@ -334,32 +370,39 @@ export const useArtist = defineStore("artist", {
           this.discogsArtist = null;
         }
 
-        // Update wikidata fields: set or clear; clear related data when absent
+        // Update wikidata fields: set or clear; clear related data when absent.
+        // Started here rather than after `getIds` returns: Wikidata and Wikipedia are
+        // unrelated hosts, so making the info tab wait on the MusicBrainz release-group
+        // pagination (now paced at ~1.1s per page) below buys nothing. Not awaited — the
+        // discography must not block on it, and it owns `timelineLoading` on its own.
         if (wikidataId) {
           this.wikidataId = wikidataId;
+          void this.getWikidataArtist(wikidataId);
         } else {
           this.wikidataId = null;
           this.wikidataArtist = null;
           this.wikipediaExtract = null;
-          this.timelineLoading = false;
         }
 
         this.reclassifying = true;
         await Promise.all(classification);
       } catch {
+        if (signal.aborted) return;
         this.discogsId = null;
         this.wikidataId = null;
-        this.timelineLoading = false;
       } finally {
-        this.reclassifying = false;
+        if (!signal.aborted) this.reclassifying = false;
       }
     },
 
     async getRelatedArtists(artistId: string) {
+      const { signal } = navigationController;
       try {
         const { data } = await instance().get<RelatedArtists>(
           `artists/${artistId}/related-artists`,
+          { signal },
         );
+        if (signal.aborted) return;
         this.relatedArtists.artists = data.artists.slice(0, 15);
       } catch {
         // silent fail
@@ -367,9 +410,10 @@ export const useArtist = defineStore("artist", {
     },
 
     async getReleaseGroups(musicbrainzId: string) {
+      const { signal } = navigationController;
       try {
-        const groups = await getMusicBrainzReleaseGroups(musicbrainzId);
-        if (!groups.length) return;
+        const groups = await getMusicBrainzReleaseGroups(musicbrainzId, signal);
+        if (!groups.length || signal.aborted) return;
 
         // MusicBrainz wins over any Discogs data already present.
         this.releaseTypes = new Map([
@@ -387,10 +431,13 @@ export const useArtist = defineStore("artist", {
     },
 
     async getSingles(artistId: string) {
+      const { signal } = navigationController;
       try {
         const { data } = await instance().get<Paging<AlbumSimplified>>(
           `artists/${artistId}/albums?market=FR&include_groups=single&limit=50`,
+          { signal },
         );
+        if (signal.aborted) return;
 
         const onlySingles: AlbumSimplified[] = [];
         const onlyEps: AlbumSimplified[] = [];
@@ -430,10 +477,13 @@ export const useArtist = defineStore("artist", {
     },
 
     async getTopTracks(artistId: string) {
+      const { signal } = navigationController;
       try {
         const { data } = await instance().get<ArtistTopTracks>(
           `artists/${artistId}/top-tracks?market=FR`,
+          { signal },
         );
+        if (signal.aborted) return;
         this.topTracks = data;
       } catch {
         // silent fail
@@ -442,15 +492,16 @@ export const useArtist = defineStore("artist", {
 
     async getWikidataArtist(wikidataArtistId: string): Promise<void> {
       if (!wikidataArtistId) return;
+      const { signal } = navigationController;
       try {
-        const { getWikidataArtist, getWikidataBandMembers } = await import("@/helpers/wikidata");
         const { mergeBandMembers } = await import("@/helpers/bandMembers");
 
         // Artist info and member list are independent — fetch in parallel
         const [wikidataArtist, wikidataMembers] = await Promise.all([
-          getWikidataArtist(wikidataArtistId),
-          getWikidataBandMembers(wikidataArtistId),
+          getWikidataArtist(wikidataArtistId, signal),
+          getWikidataBandMembers(wikidataArtistId, signal),
         ]);
+        if (signal.aborted) return;
         this.wikidataArtist = wikidataArtist;
         this.bandMembers = mergeBandMembers(wikidataMembers, this.bandMembers);
 
@@ -465,21 +516,24 @@ export const useArtist = defineStore("artist", {
         // Timeline and extract both depend on wikidataArtist but are independent of each other
         const timelinePromise = wikipediaUrl
           ? import("@/helpers/wikipediaTimeline").then(({ getWikipediaTimeline }) =>
-              getWikipediaTimeline(wikipediaUrl),
+              getWikipediaTimeline(wikipediaUrl, signal),
             )
           : Promise.resolve(null);
-        const extractPromise = selectedLang ? getWikipediaExtract(selectedLang.url) : Promise.resolve(null);
+        const extractPromise = selectedLang
+          ? getWikipediaExtract(selectedLang.url, signal)
+          : Promise.resolve(null);
 
         const [newTimeline, extract] = await Promise.all([timelinePromise, extractPromise]);
+        if (signal.aborted) return;
         this.wikiTimeline = newTimeline;
         if (selectedLang) {
           this.wikipediaLanguage = selectedLang.code;
           this.wikipediaExtract = extract;
         }
       } catch {
-        this.wikidataArtist = null;
+        if (!signal.aborted) this.wikidataArtist = null;
       } finally {
-        this.timelineLoading = false;
+        if (!signal.aborted) this.timelineLoading = false;
       }
     },
 
@@ -629,8 +683,10 @@ export const useArtist = defineStore("artist", {
     },
 
     async switchWikipediaLanguage(url: string, languageCode: string) {
+      const { signal } = navigationController;
       this.wikipediaLanguage = languageCode;
-      this.wikipediaExtract = await getWikipediaExtract(url);
+      const extract = await getWikipediaExtract(url, signal);
+      if (!signal.aborted) this.wikipediaExtract = extract;
     },
 
     updateHeaderHeight(height: number) {


### PR DESCRIPTION
Implement request aborting for Discogs, MusicBrainz, Wikidata, and Wikipedia helpers to cancel pending operations when navigating between artists. Introduce a shared request queue for MusicBrainz to enforce rate
limits across concurrent requests and prevent stale requests from blocking new navigation.