### PR TITLE
feat(artist): add Last.fm popularity badges to albums

### DIFF
--- a/src/@types/Artist.ts
+++ b/src/@types/Artist.ts
@@ -45,6 +45,8 @@ export interface ArtistPage {
   scrolledDown: boolean;
   singles: AlbumSimplified[];
   timelineLoading: boolean;
+  /** Normalized album name → Last.fm playcount rank (1 = most played). */
+  topAlbumRanks: Map<string, number>;
   topTracks: ArtistTopTracks;
   wikidataArtist: null | WikidataArtist;
   wikidataId: null | string;

--- a/src/@types/Lastfm.ts
+++ b/src/@types/Lastfm.ts
@@ -1,7 +1,17 @@
+export interface LastfmArtistTopAlbums {
+  topalbums?: {
+    album: LastfmTopAlbum[];
+  };
+}
+
 export interface LastfmTagTopArtists {
   topartists?: {
     artist: LastfmTopArtist[];
   };
+}
+
+export interface LastfmTopAlbum {
+  name: string;
 }
 
 export interface LastfmTopArtist {

--- a/src/components/artist/BlockAlbums.vue
+++ b/src/components/artist/BlockAlbums.vue
@@ -5,7 +5,10 @@
       Albums
     </div>
     <div class="albums">
-      <div v-for="group in albumGroups" :key="group.baseAlbum.id">
+      <div v-for="group in albumGroups" :key="group.baseAlbum.id" class="album-slot">
+        <Tooltip v-if="rank(group)" :text="tooltipText(group)" class="rank-badge">
+          <span class="rank-badge-bubble font-bold">{{ rank(group) }}</span>
+        </Tooltip>
         <AlbumGroup :group="group" can-save clean-name />
       </div>
     </div>
@@ -16,12 +19,56 @@
 import { computed } from "vue";
 
 import AlbumGroup from "@/components/album/AlbumGroup.vue";
-import { groupAlbumVariants } from "@/helpers/groupAlbumVariants";
+import Tooltip from "@/components/ui/Tooltip.vue";
+import { AlbumGroup as AlbumGroupType, getDisplayName, groupAlbumVariants } from "@/helpers/groupAlbumVariants";
+import { normalizeString } from "@/helpers/helper";
 import { useArtist } from "@/views/artist/ArtistStore";
+
+/**
+ * One badge per this many albums: a fixed count would badge most of a 4-album
+ * discography and only scratch a 30-album one, where picking an entry point is
+ * exactly where the help is needed. Never fewer than a top 3.
+ */
+const ALBUMS_PER_HIGHLIGHT = 4;
+const MIN_HIGHLIGHTS = 3;
 
 const artistStore = useArtist();
 
 const albumGroups = computed(() => groupAlbumVariants(artistStore.albums));
+
+const highlightCount = computed(() =>
+  Math.max(MIN_HIGHLIGHTS, Math.round(albumGroups.value.length / ALBUMS_PER_HIGHLIGHT)),
+);
+
+/**
+ * Positions are recomputed over the studio albums actually listed here rather than
+ * reused from Last.fm: its ranking mixes in compilations and live records, which
+ * live in their own blocks, so raw ranks would leave gaps (a lone #2 and #5).
+ */
+const highlights = computed(() => {
+  const ranks = artistStore.topAlbumRanks;
+  if (!ranks.size) return new Map<string, number>();
+
+  // Same normalization as the Last.fm side, so both keys are built identically.
+  const lastfmRank = (group: AlbumGroupType): number | undefined =>
+    ranks.get(normalizeString(getDisplayName(group.baseAlbum.name)));
+
+  return new Map(
+    albumGroups.value
+      .flatMap((group) => {
+        const r = lastfmRank(group);
+        return r === undefined ? [] : [[group.baseAlbum.id, r] as const];
+      })
+      .sort((a, b) => a[1] - b[1])
+      .slice(0, highlightCount.value)
+      .map(([id], index) => [id, index + 1]),
+  );
+});
+
+const rank = (group: AlbumGroupType): number | undefined => highlights.value.get(group.baseAlbum.id);
+
+const tooltipText = (group: AlbumGroupType): string =>
+  `#${rank(group)} most played album on Last.fm`;
 </script>
 
 <style scoped>
@@ -30,5 +77,36 @@ const albumGroups = computed(() => groupAlbumVariants(artistStore.albums));
   display: grid;
   gap: 1.2rem;
   grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));
+}
+
+.album-slot {
+  position: relative;
+}
+
+/* Positioning only — the Tooltip root carries the hover area, so it can't be
+   pointer-events: none; it overlaps a corner of the cover, clickable elsewhere.
+   Descendant selector on purpose: Tooltip's own root rule sets position:
+   relative at equal specificity, and cross-file source order isn't guaranteed. */
+.album-slot .rank-badge {
+  left: -0.4rem;
+  position: absolute;
+  top: -0.4rem;
+  z-index: 2;
+}
+
+.rank-badge-bubble {
+  --rank-badge-size: 1.5rem;
+
+  align-items: center;
+  background-color: var(--bg-color-light);
+  border-radius: 50%;
+  box-shadow: 0 0 0 2px var(--bg-color-darker);
+  color: var(--font-color-light);
+  cursor: help;
+  display: flex;
+  font-size: var(--font-size-xs);
+  height: var(--rank-badge-size);
+  justify-content: center;
+  width: var(--rank-badge-size);
 }
 </style>

--- a/src/components/artist/BlockAlbums.vue
+++ b/src/components/artist/BlockAlbums.vue
@@ -1,11 +1,21 @@
 <template>
   <div v-if="artistStore.albums.length" class="content-block">
-    <div :style="{ top: artistStore.headerHeight + 'px' }" class="heading sticky-heading">
+    <div :style="{ top: artistStore.headerHeight + 'px' }" class="heading sticky-heading album-heading">
       <i class="icon-album" />
       Albums
+      <ButtonIndex
+        v-if="canSortByPlays"
+        class="sort-button"
+        size="x-small"
+        variant="nude"
+        @click="sortByPlays = !sortByPlays"
+      >
+        {{ sortByPlays ? "Most played" : "Release date" }}
+        <i class="icon-arrow-down" />
+      </ButtonIndex>
     </div>
     <div class="albums">
-      <div v-for="group in albumGroups" :key="group.baseAlbum.id" class="album-slot">
+      <div v-for="group in sortedGroups" :key="group.baseAlbum.id" class="album-slot">
         <Tooltip v-if="rank(group)" :text="tooltipText(group)" class="rank-badge">
           <span class="rank-badge-bubble font-bold">{{ rank(group) }}</span>
         </Tooltip>
@@ -16,9 +26,10 @@
 </template>
 
 <script lang="ts" setup>
-import { computed } from "vue";
+import { computed, ref } from "vue";
 
 import AlbumGroup from "@/components/album/AlbumGroup.vue";
+import ButtonIndex from "@/components/ui/ButtonIndex.vue";
 import Tooltip from "@/components/ui/Tooltip.vue";
 import { AlbumGroup as AlbumGroupType, getDisplayName, groupAlbumVariants } from "@/helpers/groupAlbumVariants";
 import { normalizeString } from "@/helpers/helper";
@@ -34,7 +45,32 @@ const MIN_HIGHLIGHTS = 3;
 
 const artistStore = useArtist();
 
+/** false = release date (default, newest first), true = Last.fm plays, most first. */
+const sortByPlays = ref(false);
+
 const albumGroups = computed(() => groupAlbumVariants(artistStore.albums));
+
+/** Same normalization as the Last.fm side, so both keys are built identically. */
+function lastfmRank(group: AlbumGroupType): number | undefined {
+  return artistStore.topAlbumRanks.get(normalizeString(getDisplayName(group.baseAlbum.name)));
+}
+
+const canSortByPlays = computed(() => artistStore.topAlbumRanks.size > 0);
+
+/**
+ * `groupAlbumVariants` already returns newest-first, so the default mode reuses
+ * that order untouched. Albums Last.fm doesn't rank keep their date order at the
+ * bottom: an unknown play count is not a low one, and sinking them beats
+ * interleaving them arbitrarily.
+ */
+const sortedGroups = computed(() => {
+  if (!sortByPlays.value) return albumGroups.value;
+
+  const ranked = albumGroups.value.filter((group) => lastfmRank(group) !== undefined);
+  const unranked = albumGroups.value.filter((group) => lastfmRank(group) === undefined);
+
+  return [...ranked.sort((a, b) => (lastfmRank(a) as number) - (lastfmRank(b) as number)), ...unranked];
+});
 
 const highlightCount = computed(() =>
   Math.max(MIN_HIGHLIGHTS, Math.round(albumGroups.value.length / ALBUMS_PER_HIGHLIGHT)),
@@ -46,12 +82,7 @@ const highlightCount = computed(() =>
  * live in their own blocks, so raw ranks would leave gaps (a lone #2 and #5).
  */
 const highlights = computed(() => {
-  const ranks = artistStore.topAlbumRanks;
-  if (!ranks.size) return new Map<string, number>();
-
-  // Same normalization as the Last.fm side, so both keys are built identically.
-  const lastfmRank = (group: AlbumGroupType): number | undefined =>
-    ranks.get(normalizeString(getDisplayName(group.baseAlbum.name)));
+  if (!canSortByPlays.value) return new Map<string, number>();
 
   return new Map(
     albumGroups.value
@@ -72,6 +103,17 @@ const tooltipText = (group: AlbumGroupType): string =>
 </script>
 
 <style scoped>
+
+.album-heading {
+  align-items: center;
+  display: flex;
+  gap: 0.4rem;
+}
+
+.sort-button {
+  margin-left: auto;
+  text-transform: none;
+}
 
 .albums {
   display: grid;

--- a/src/helpers/lastfm.ts
+++ b/src/helpers/lastfm.ts
@@ -1,8 +1,64 @@
-import { LastfmTagTopArtists } from "@/@types/Lastfm";
+import { LastfmArtistTopAlbums, LastfmTagTopArtists } from "@/@types/Lastfm";
+import { getDisplayName } from "@/helpers/groupAlbumVariants";
+import { normalizeString } from "@/helpers/helper";
 import { http } from "@/helpers/http";
 
 const LASTFM_API_URL = "https://ws.audioscrobbler.com/2.0/";
 const LASTFM_API_KEY = import.meta.env.VITE_LASTFM_API_KEY || "";
+
+/**
+ * Rank an artist's albums by Last.fm playcount — i.e. what listeners actually
+ * play, which is the only public signal for "start with this one". Spotify's
+ * API exposes no popularity on simplified album objects, so a per-album lookup
+ * there would mean one extra request per release.
+ *
+ * Names go through `getDisplayName` + `normalizeString` so they can be matched
+ * against Spotify titles: Last.fm often carries an edition suffix Spotify lacks
+ * ("L'Enfant Sauvage (Special Edition)"), on top of punctuation/casing drift.
+ * @param artistName - Artist name as known to Spotify
+ * @param limit - Max number of albums to rank
+ * @param signal - Abort signal, cancelled on artist-page navigation
+ * @returns Map of normalized album name → rank (1 = most played), empty on error or no key
+ */
+export async function getTopAlbumRanks(
+  artistName: string,
+  limit = 10,
+  signal?: AbortSignal,
+): Promise<Map<string, number>> {
+  if (!LASTFM_API_KEY || !artistName) return new Map();
+
+  try {
+    const data = await http
+      .get(LASTFM_API_URL, {
+        searchParams: {
+          api_key: LASTFM_API_KEY,
+          artist: artistName,
+          autocorrect: 1,
+          format: "json",
+          limit,
+          method: "artist.gettopalbums",
+        },
+        signal,
+      })
+      .json<LastfmArtistTopAlbums>();
+
+    // Last.fm files unmatched scrobbles under a literal "(null)" album.
+    const names = (data.topalbums?.album ?? [])
+      .map((album) => normalizeString(getDisplayName(album.name)))
+      .filter((name) => name !== "" && name !== "null");
+
+    // Stripping edition suffixes can collapse two entries onto one title — the
+    // first occurrence is the better-played one, so it keeps the rank.
+    const ranks = new Map<string, number>();
+    names.forEach((name) => {
+      if (!ranks.has(name)) ranks.set(name, ranks.size + 1);
+    });
+
+    return ranks;
+  } catch {
+    return new Map();
+  }
+}
 
 /**
  * Get the top artists for a genre/tag from Last.fm's crowd-sourced tag data.

--- a/src/views/artist/ArtistStore.ts
+++ b/src/views/artist/ArtistStore.ts
@@ -12,6 +12,7 @@ import {
   processDiscogsReleases,
 } from "@/helpers/discogs";
 import { normalizeString } from "@/helpers/helper";
+import { getTopAlbumRanks } from "@/helpers/lastfm";
 import { isInLibrary, removeFromLibrary, saveToLibrary } from "@/helpers/library";
 import {
   buildBaseTitleMap,
@@ -168,6 +169,7 @@ export const useArtist = defineStore("artist", {
       this.wikipediaLanguage = "en";
       this.wikiTimeline = null;
       this.topTracks = { tracks: [] };
+      this.topAlbumRanks = new Map();
       this.albums = [];
       this.albumsLive = [];
       this.albumsCompilation = [];
@@ -222,6 +224,14 @@ export const useArtist = defineStore("artist", {
         const { data } = await instance().get<Artist>(`artists/${artistId}`, { signal });
         if (signal.aborted) return;
         this.artist = data;
+
+        // Last.fm popularity ranking — independent of the MB/Wikidata chain below,
+        // so it must not delay it (nor be delayed by it).
+        // 30, not the ~3 badges shown: the list also holds compilations and live
+        // records (filed in their own blocks), and long careers badge more albums.
+        void getTopAlbumRanks(data.name, 30, signal).then((ranks) => {
+          if (!signal.aborted) this.topAlbumRanks = ranks;
+        });
 
         // Fetch external IDs and data (Spotify ID used for exact MusicBrainz match).
         // `getIds` starts the Wikidata chain itself, as soon as the id is known.
@@ -715,6 +725,7 @@ export const useArtist = defineStore("artist", {
     scrolledDown: false,
     singles: [],
     timelineLoading: false,
+    topAlbumRanks: new Map(),
     topTracks: { tracks: [] },
     wikidataArtist: null,
     wikidataId: null,


### PR DESCRIPTION
Display ranking badges on the top 3 most played albums based on Last.fm data, helping users identify where to start with an artist.