### PR TITLE
fix(api): improve MusicBrainz 503 resilience

### DIFF
--- a/src/helpers/musicbrainz.ts
+++ b/src/helpers/musicbrainz.ts
@@ -1,4 +1,4 @@
-import ky from "ky";
+import ky, { HTTPError } from "ky";
 
 import type { BandMember } from "@/@types/Artist";
 
@@ -439,20 +439,31 @@ async function fetchFromMusicBrainz<T>(
   searchParams: Record<string, number | string> = {},
   signal?: AbortSignal,
 ): Promise<null | T> {
-  try {
-    return await enqueue(async () => {
-      const response = await musicbrainzClient.get(path, {
-        searchParams: {
-          fmt: "json",
-          ...searchParams,
-        },
-        signal,
-      });
+  const request = async (): Promise<null | T> => enqueue(async () => {
+    const response = await musicbrainzClient.get(path, {
+      searchParams: {
+        fmt: "json",
+        ...searchParams,
+      },
+      signal,
+    });
 
-      return await response.json<T>();
-    }, signal);
-  } catch {
-    return null;
+    return await response.json<T>();
+  }, signal);
+
+  try {
+    return await request();
+  } catch (error) {
+    // MusicBrainz answers 503 whenever its throttle trips, even at the paced rate. Retrying once
+    // through the queue puts the second try at least MIN_REQUEST_INTERVAL_MS later, which is what
+    // the service asks for. Any other failure (404, timeout, abort) is final.
+    if (!(error instanceof HTTPError) || error.response.status !== 503) return null;
+
+    try {
+      return await request();
+    } catch {
+      return null;
+    }
   }
 }
 

--- a/src/views/artist/ArtistStore.ts
+++ b/src/views/artist/ArtistStore.ts
@@ -357,7 +357,13 @@ export const useArtist = defineStore("artist", {
               ? ((await searchMusicBrainzBySpotifyId(spotifyId, signal)) ?? nameResults[0])
               : nameResults[0] ?? null;
 
-        if (!artist?.id) return;
+        if (!artist?.id || signal.aborted) return;
+
+        // The search document already carries everything the profile header shows (country,
+        // area, life-span, tags, disambiguation); the lookup below only adds relations
+        // (members, Discogs/Wikidata ids). Publish it now so a MusicBrainz failure on that
+        // lookup — 503 is routine there — leaves the header filled instead of blank.
+        this.musicbrainzArtist = artist;
 
         const artistFull = await getIdsFromMusicBrainz(artist.id, signal);
         if (!artistFull || signal.aborted) return;


### PR DESCRIPTION
- Retry requests once if a 503 Service Unavailable error occurs
- Update store to populate artist data before secondary relation lookup