### PR TITLE
fix(dev): update proxy rules and artist visibility

### DIFF
--- a/src/components/artist/ArtistProfile.vue
+++ b/src/components/artist/ArtistProfile.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="profile-container font-bold">
-    <div class="profile-wrapper" :class="{ visible: artistMetas }">
+    <div class="profile-wrapper" :class="{ visible: artistMetas || artistTags.length > 0 }">
       <template v-if="artistTags && artistTags.length > 0">
         <span class="tag-list">
           <router-link

--- a/src/helpers/musicbrainz.ts
+++ b/src/helpers/musicbrainz.ts
@@ -1,4 +1,4 @@
-import ky, { HTTPError } from "ky";
+import ky, { HTTPError, TimeoutError } from "ky";
 
 import type { BandMember } from "@/@types/Artist";
 
@@ -329,8 +329,10 @@ export async function getIdsFromMusicBrainz(
   musicbrainzId: string,
   signal?: AbortSignal,
 ): Promise<MusicBrainzArtist | null> {
+  // `tags` rides along on this one request: callers can reach the artist through the Spotify
+  // URL lookup, whose embedded stub carries no tags, so the header would lose its genre links.
   return fetchFromMusicBrainz<MusicBrainzArtist>(`artist/${musicbrainzId}`, {
-    inc: "artist-rels+url-rels",
+    inc: "artist-rels+url-rels+tags",
   }, signal);
 }
 
@@ -475,6 +477,10 @@ async function fetchFromMusicBrainz<T>(
     try {
       return await request();
     } catch (error) {
+      // Timeouts join the retryable set: MusicBrainz occasionally stalls well past the 10s
+      // client timeout, and the next try normally lands in under a second.
+      if (error instanceof TimeoutError) continue;
+
       const status = error instanceof HTTPError ? error.response.status : 0;
       if (status !== 502 && status !== 503) return null;
     }

--- a/src/helpers/musicbrainz.ts
+++ b/src/helpers/musicbrainz.ts
@@ -155,6 +155,15 @@ const musicbrainzClient = ky.create({
  * spaces them instead of each caller racing the limit on its own.
  */
 const MIN_REQUEST_INTERVAL_MS = 1100;
+
+/**
+ * Total tries per request, not extra ones. Two sources of transient failure make a single
+ * try unreliable: MusicBrainz serves 503 from its global "server busy" zone even when the
+ * per-IP quota is untouched (`x-ratelimit-remaining` stays high, `retry-after` is 0), and it
+ * answers `Connection: close`, so a reused keep-alive socket can die mid-request and surface
+ * as a 502 from the dev proxy. Both clear on a later try, and each try costs one queue slot.
+ */
+const MAX_ATTEMPTS = 3;
 let requestQueue: Promise<unknown> = Promise.resolve();
 let lastRequestAt = 0;
 
@@ -459,20 +468,19 @@ async function fetchFromMusicBrainz<T>(
     return await response.json<T>();
   }, signal);
 
-  try {
-    return await request();
-  } catch (error) {
-    // MusicBrainz answers 503 whenever its throttle trips, even at the paced rate. Retrying once
-    // through the queue puts the second try at least MIN_REQUEST_INTERVAL_MS later, which is what
-    // the service asks for. Any other failure (404, timeout, abort) is final.
-    if (!(error instanceof HTTPError) || error.response.status !== 503) return null;
-
+  // Every retry goes back through the queue, so tries land at least MIN_REQUEST_INTERVAL_MS
+  // apart — the pacing MusicBrainz asks for. Only the transient statuses are retried; anything
+  // else (404, timeout, abort) is final and returns null on the spot.
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
     try {
       return await request();
-    } catch {
-      return null;
+    } catch (error) {
+      const status = error instanceof HTTPError ? error.response.status : 0;
+      if (status !== 502 && status !== 503) return null;
     }
   }
+
+  return null;
 }
 
 /**

--- a/src/views/artist/ArtistStore.ts
+++ b/src/views/artist/ArtistStore.ts
@@ -347,22 +347,24 @@ export const useArtist = defineStore("artist", {
       this.wikidataArtist = null;
       this.wikipediaExtract = null;
       try {
-        // Search by name first; if multiple homonyms found and Spotify ID available,
-        // use Spotify URL lookup for exact match
-        const nameResults = await searchMusicBrainzArtistId(artistName, signal);
-        const artist
-          = nameResults.length === 1
-            ? nameResults[0]
-            : nameResults.length > 1 && spotifyId
-              ? ((await searchMusicBrainzBySpotifyId(spotifyId, signal)) ?? nameResults[0])
-              : nameResults[0] ?? null;
+        // Spotify link first, name search only as fallback. MusicBrainz serves its search
+        // index (`/artist?query=`) from a "global" rate-limit zone that answers 503 about
+        // half the time — measured, with the per-IP quota untouched — while the /url lookup
+        // is a plain index read that answers reliably. It is also the exact match, so the
+        // homonym tie-break the name search needed disappears with it.
+        const linked = spotifyId ? await searchMusicBrainzBySpotifyId(spotifyId, signal) : null;
+        if (signal.aborted) return;
+
+        // No Spotify link on the MusicBrainz side (404 there is common for small artists).
+        const artist = linked ?? (await searchMusicBrainzArtistId(artistName, signal))[0] ?? null;
 
         if (!artist?.id || signal.aborted) return;
 
-        // The search document already carries everything the profile header shows (country,
-        // area, life-span, tags, disambiguation); the lookup below only adds relations
-        // (members, Discogs/Wikidata ids). Publish it now so a MusicBrainz failure on that
-        // lookup — 503 is routine there — leaves the header filled instead of blank.
+        // Publish what the resolver returned before the lookup below: a MusicBrainz failure
+        // on that request then leaves the header partly filled instead of blank. The search
+        // document carries the whole header (country, area, life-span, tags, disambiguation);
+        // the URL-lookup stub carries only country and disambiguation, and the lookup fills
+        // the rest in.
         this.musicbrainzArtist = artist;
 
         const artistFull = await getIdsFromMusicBrainz(artist.id, signal);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -72,19 +72,21 @@ export default defineConfig({
     host: "127.0.0.1",
     port: 3000,
     proxy: {
-      "/.netlify/functions": {
-        changeOrigin: true,
-        target: "http://localhost:9999",
-      },
-      // Ahead of the generic entry below (first match wins): plain `bun run dev` has no
-      // function host, and MusicBrainz is the one relay the app can't work without. Node
-      // can set the User-Agent the browser refuses to, so dev gets the same treatment as
-      // the deployed function.
+      // Plain `bun run dev` has no function host, and MusicBrainz is the one relay the app
+      // can't work without. Node can set the User-Agent the browser refuses to, so dev gets
+      // the same treatment as the deployed function.
       "/.netlify/functions/musicbrainz": {
         changeOrigin: true,
         headers: { "User-Agent": "Beardify/1.0.0 (https://github.com/BeardedBear/beardify)" },
         rewrite: (path): string => path.replace("/.netlify/functions/musicbrainz", "/ws/2"),
         target: "https://musicbrainz.org",
+      },
+      // Regex, not a plain prefix: Vite tries every proxy context and this one would
+      // swallow the MusicBrainz path whatever the key order, sending it to a function
+      // host that plain `bun run dev` never starts (ECONNREFUSED -> 502).
+      "^/[.]netlify/functions/(?!musicbrainz)": {
+        changeOrigin: true,
+        target: "http://localhost:9999",
       },
     },
   },


### PR DESCRIPTION
- Update Vite proxy regex to prevent swallowing MusicBrainz requests
- Show artist profile wrapper if tags exist even if metadata is absent