### PR TITLE
fix(player): seek precision, shared clock and animation fixes

### DIFF
--- a/.impeccable/critique/2026-08-25T21-51-30Z__src-components-player-seekbar-vue.md
+++ b/.impeccable/critique/2026-08-25T21-51-30Z__src-components-player-seekbar-vue.md
@@ -1,0 +1,95 @@
+---
+target: seekbar
+total_score: 17
+max_score: 36
+na_heuristics: 10
+p0_count: 1
+p1_count: 3
+timestamp: 2026-08-25T21-51-30Z
+slug: src-components-player-seekbar-vue
+---
+`Method: dual-agent (A: design review · B: detector + static evidence) — isolés, en parallèle.`
+
+# Critique — src/components/player/SeekBar.vue
+
+Mode : **Operate**.
+
+## Design Health Score
+
+| # | Heuristique | Note | Problème clé |
+|---|---|---|---|
+| 1 | Visibilité de l'état système | 2 | Aucun état pendant le commit ; rubber-band sur device externe ; barre vivante avec `max=0` pendant un switch |
+| 2 | Correspondance système / monde réel | 3 | `timecode(0)` renvoie `""` → aria-valuetext « of 3:45 » sans position |
+| 3 | Contrôle et liberté | 2 | Pas de ±10 s ; Échap n'annule pas un drag |
+| 4 | Cohérence et standards | 1 | DeviceVolume a reçu 4 correctifs, la seekbar 0 |
+| 5 | Prévention des erreurs | 1 | `:max="duration || 0"` → contrôle dégénéré actif ; `disallows.seeking` jamais lu |
+| 6 | Reconnaissance plutôt que rappel | 3 | Chiffres dans un autre composant, autre ticker |
+| 7 | Flexibilité et efficacité | 1 | `step="1000"` ; aucun raccourci global de seek |
+| 8 | Esthétique et minimalisme | 4 | Rail 2 px, pas de thumb, preview à la demande |
+| 9 | Diagnostic et récupération d'erreur | 0 | `seek()` : ni try, ni rollback, ni notification |
+| 10 | Aide et documentation | n/a | Affordance universelle, preview auto-documentante |
+| **Total** | | **17/36** | **Poor (47 %)** |
+
+## Design Specificity Verdict
+
+Partiellement authored. Propre à Beardify : rail `0.2rem` sans thumb, et surtout le `scaleX` composité dont `transition: transform linear 0.2s` est calibrée sur `freq = 200`. Le reste est interchangeable — et le wedge `clip-path` qui signe DeviceVolume.vue:199 est absent ici : deux sliders côte à côte sans vocabulaire commun.
+
+**Scan déterministe** : `detect.mjs` → 0 finding sur la cible, 0 sur `src/components/player`, EXIT=0. Contrôle vérifié (un `.vue` avec `font-family: Inter` déclenche bien `overused-font`), mais sur ~12 anti-patterns plantés seuls 3 remontent : depuis un fichier source seul le moteur `regex` est atteignable (`detector/registry/antipatterns.mjs:559`), donc contraste, layout et tailles calculées ne sont jamais évalués. EXIT=0 = « aucun motif source », pas « composant sain ».
+
+**Overlays** : aucun. Pas d'outil navigateur exposé, cible derrière OAuth Premium. Ratios calculés hors ligne depuis les formules oklch de themes.css.
+
+## Overall Impression
+
+Soins de performance réels, soins d'interaction inexistants. `DeviceVolume.vue` est déjà la version corrigée de ce fichier : thumb zéro-largeur, preview au focus, verrou anti-resync, rollback + notification. La seekbar n'en a aucun, pour un contrôle dix fois plus utilisé.
+
+## What's Working
+
+1. `scaleX` synchronisé sur le ticker (SeekBar.vue:152-162 + 76-83) — transition 200 ms remplacée toutes les 200 ms, en `linear`, zéro layout.
+2. Clamp défensif (SeekBar.vue:81 + 73) contre un SDK bloqué sur `paused: false`.
+3. Split `onScrub`/`onCommit` (@input vs @change) — un seul appel API par drag ; le passage à un vrai `<input type=range>` a apporté clavier, tactile et ARIA.
+
+## Priority Issues
+
+### [P0] Le clic n'atterrit pas où pointe le curseur
+SeekBar.vue:176-187 — `appearance: none` sans règle de thumb → thumb par défaut ~16-20 px, valeur répartie sur `width − thumbWidth`, alors que le tooltip utilise `elementX / elementWidth` (ligne 63). Erreur max 8 px = 0,57 % de la durée → ~1,4 s sur un titre, ~20 s sur un épisode d'1 h ; 8 px morts à chaque bord. Fix : `::-webkit-slider-thumb`/`::-moz-range-thumb` en `width: 0` (copie de DeviceVolume.vue:246-263). Commande : /impeccable harden
+
+### [P1] `seek()` est le seul contrôle optimiste sans filet
+PlayerStore.ts:283-287 — aucun try : unhandled rejection, aucun rollback, aucune notification. toggleShuffle (446-461), toggleRepeat et setVolumeOptimistic font les trois. Fix : prevPosition + try/catch + notification. Commande : /impeccable harden
+
+### [P1] Rubber-band du seek sur device externe
+PlayerIndex.vue:42-44 poll toutes les 2 s (device externe) → PlayerStore.ts:214 écrase `position` avec une valeur périmée → watch SeekBar.vue:88 (delta > 1500) ramène la barre en arrière puis en avant. Le mécanisme correct existe 4 lignes plus bas : `volumeLockUntil` (29, 218, 301). Fix : `seekLockUntil` + garde sur la ligne 214. Commande : /impeccable harden
+
+### [P1] Pas de seek clavier praticable, ni read-out au focus
+`step="1000"` (ligne 25) ; `.seek` seulement sur `:hover` (169-173) alors que DeviceVolume.vue:276-283 la révèle sur `:has(.range:focus-visible)` ; `useKeyboardEvents.ts` a Shift+↑/↓ pour le volume et rien pour le seek. Fix : step proportionnel, `.seek` dans le bloc `:has()` existant (ligne 189), ←/→ = ±10 s. Commande : /impeccable adapt
+
+### [P2] Contrôle actif et dégénéré pendant le chargement
+`:max="duration || 0"` (ligne 21) → min = max = 0, range interactif, tout clic = `seek(0)`. Plus PlayerStore.ts:52 : `this.playerState = defaultPlaybackState` assigne par référence l'objet module-level exporté, donc les mutations polluent le défaut partagé. Fix : `:disabled="!duration"` + `{ ...defaultPlaybackState }`. Commande : /impeccable harden
+
+### [P3] Contraste du tooltip sous AA
+SeekBar.vue:133-137 — `--font-color-light` sur `--primary-color` à 12,3 px : 3,20:1 vs 4,5 requis. `--bd-on-primary` vaut `#fff` → 3,85:1, insuffisant seul. Fix : assombrir le fond (`--primary-color-darker`, ~7:1, tient sur toutes les palettes). Commande : /impeccable colorize
+
+## Persona Red Flags
+
+**Alex (power user)** — 1 s par flèche, aucun raccourci de seek (le volume a Shift+↑/↓) ; cible de 18,3 px au pointeur fin (sous les 24 px de WCAG 2.5.8) ; aucun marqueur ni ±30 s ; la seekbar n'affiche même pas sa durée.
+
+**Sam (clavier + lecteur d'écran)** — `aria-valuetext` « of 3:45 » à la position 0 (date.ts:68 ; le fallback existe déjà dans PlayerControls.vue:56) ; aucun read-out visible pendant un scrub clavier ; `aria-label="Seek"` sans contexte, deux SeekBar montées en permanence (App.vue:18-19) ; échec de seek totalement silencieux ; ~37 px en pointer: coarse.
+
+**Le mainteneur (device distant)** — le rubber-band est son bug exclusif ; aucun signal d'attente d'ack, donc re-clic ; deux instances tournent en permanence (deux intervalles 5 Hz + deux listeners mousemove document-level) ; chemin épisode abandonné — PlayerEpisode.vue:15 passe `:duration=` à un composant sans props, l'attribut retombe en attribut DOM mort.
+
+## Minor Observations
+
+- SeekBar.vue:64 — `if (durationPerc)` : à l'extrême gauche la valeur est 0 → falsy → tooltip périmé au bord le plus utile.
+- SeekBar.vue:123 — `opacity: 0.5` est mort : `animation … both` avec `to { opacity: 1 }` gagne la cascade et le fill-mode la maintient.
+- SeekBar.vue:132-143 — pas de `tabular-nums` sur `.time` (PlayerControls.vue:98 l'a) → le tooltip tressaute.
+- SeekBar.vue:121 — `pop-seek 0.5s` redémarre à chaque hover ; 120 ms suffisent.
+- SeekBar.vue:68-69 — addEventListener manuel alors que `useMouseInElement` est déjà réactif ; `perc` et `time` pourraient être un seul computed.
+- SeekBar.vue:116 — `flex: 1` sans ancêtre flex : déclaration morte.
+- 4 border-radius en dur dupliquent `--bd-radius-lg`/`--bd-radius-sm` (le pont bearded-ui.css n'aliase pas les radius) ; 7 espacements sur 7 hors échelle `--space-*`.
+- Aucun breakpoint littéral ; 5 var() sur 5 définies.
+- Aucun test sur le mapping du seek, alors que volume.test.ts existe.
+
+## Questions to Consider
+
+1. Pourquoi le volume a-t-il reçu langage visuel, helper testé et quatre correctifs, et pas la seekbar — dix fois plus utilisée, et seule à piloter ce qu'on ne peut pas récupérer ?
+2. Pourquoi la barre la plus large de l'interface ne porte-t-elle aucun chiffre, et pourquoi deux composants comptent-ils le temps séparément au lieu du store ?
+3. « La lecture ne s'interrompt jamais » : ne jamais montrer d'attente, ou ne jamais faire attendre ?

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,19 @@ Beardify is a custom Spotify web client built with Vue 3 + TypeScript that enhan
 - **ky v2** for HTTP requests (via `instance()` helper)
 - **Spotify Web API + Web Playback SDK**
 
+## UI Library (bearded-ui)
+
+`bearded-ui` is the main UI library for Beardify. It lives in a sibling folder
+next to this repo (`../bearded-ui`), always checked out side by side.
+
+- **Components go to `bearded-ui` first.** When a component is missing or needs
+  changes, add/edit it in `../bearded-ui`, not locally in Beardify. Do not
+  duplicate a library component in `src/components/`.
+- Keep `bearded-ui` up to date whenever the work requires it — new component,
+  fixed prop, missing variant: the change belongs upstream.
+- The maintainer pushes the `bearded-ui` version and bumps the package here.
+  Don't publish or bump the dependency version yourself unless asked.
+
 ## Essential Commands
 
 ```bash

--- a/bun.lock
+++ b/bun.lock
@@ -870,7 +870,7 @@
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
-    "bearded-ui": ["bearded-ui@github:BeardedBear/bearded-ui#6798c19", { "dependencies": { "@phosphor-icons/vue": "^2.2.1" }, "peerDependencies": { "vue": "^3.5.0" } }, "BeardedBear-bearded-ui-6798c19", "sha512-TXuqOe3pp391N3ox1Uq1utWIbDZHIlQcB8RXgmrGPqweIChaHqn3HXfEPeQMMzBR7wnxY0hYjbR4Ze3u8peuUA=="],
+    "bearded-ui": ["bearded-ui@github:BeardedBear/bearded-ui#9a55d62", { "dependencies": { "@phosphor-icons/vue": "^2.2.1" }, "peerDependencies": { "vue": "^3.5.0" } }, "BeardedBear-bearded-ui-9a55d62", "sha512-AGoa2dStG18I7MtuGIxv/8dxjos/50CrDL6uXmtbjchJN0ZeNgl+4sPJU2uCMifcC2PI7AvhvmSNNysJHnNRDQ=="],
 
     "before-after-hook": ["before-after-hook@4.0.0", "", {}, "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -870,7 +870,7 @@
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
-    "bearded-ui": ["bearded-ui@github:BeardedBear/bearded-ui#9a55d62", { "dependencies": { "@phosphor-icons/vue": "^2.2.1" }, "peerDependencies": { "vue": "^3.5.0" } }, "BeardedBear-bearded-ui-9a55d62", "sha512-AGoa2dStG18I7MtuGIxv/8dxjos/50CrDL6uXmtbjchJN0ZeNgl+4sPJU2uCMifcC2PI7AvhvmSNNysJHnNRDQ=="],
+    "bearded-ui": ["bearded-ui@github:BeardedBear/bearded-ui#e3a0c50", { "dependencies": { "@phosphor-icons/vue": "^2.2.1" }, "peerDependencies": { "vue": "^3.5.0" } }, "BeardedBear-bearded-ui-e3a0c50", "sha512-OvarZ/6Ph9jEsF+GJf7cuNBiLLjusp7pKcf7Yhi1I/Xz/t2fQ19Q9BbnFPGHqG9IYtk3HwBd9f6g4HH8D9bddw=="],
 
     "before-after-hook": ["before-after-hook@4.0.0", "", {}, "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="],
 

--- a/src/@types/Player.ts
+++ b/src/@types/Player.ts
@@ -18,6 +18,7 @@ export interface Player {
   playerState: Spotify.PlaybackState;
   queue: Spotify.Track[];
   queueOpened: boolean;
+  seekLockUntil?: number;
   thisDeviceId: string;
   volumeLockUntil?: number;
 }

--- a/src/assets/css/heading.css
+++ b/src/assets/css/heading.css
@@ -5,8 +5,17 @@
   padding: 0.8rem 0;
   text-transform: uppercase;
 
+  /*
+   * The gap below a sticky heading has to be margin, not the shared padding:
+   * padding is inside the opaque background, and the playing album's ring is
+   * an outer box-shadow spreading 0.5rem above its card, so a first-row card
+   * had its ring painted over by the heading. Same trick as .sticky-heading in
+   * ArtistPage. Total spacing is unchanged.
+   */
   &.sticky {
     background-color: var(--bg-color-darker);
+    margin-bottom: 0.8rem;
+    padding-bottom: 0;
     position: sticky;
     top: 0;
     z-index: 3;

--- a/src/components/artist/ArtistNavigation.vue
+++ b/src/components/artist/ArtistNavigation.vue
@@ -7,26 +7,28 @@
       :class="{ stuck: isStuck }"
       :style="{ top: headerHeight + 'px' }"
     >
-      <BdSelect
-        v-if="hasSections"
-        :model-value="selectedSection"
-        :options="sectionOptions"
-        placeholder="Go to section..."
-        @update:model-value="onSectionChange"
-      />
+      <BdDropdown v-if="hasSections" label="Go to section..." match-width size="small">
+        <BdDropdownItem v-for="section in sections" :key="section.id" @click="onSectionChange(section.id)">
+          {{ section.title }}
+        </BdDropdownItem>
+      </BdDropdown>
 
-      <BdSelect
-        v-if="hasMultipleLanguages"
-        :model-value="currentLanguage"
-        :options="languageOptions"
-        @update:model-value="onLanguageChange"
-      />
+      <BdDropdown v-if="hasMultipleLanguages" :label="currentLanguageName" placement="bottom-end" size="small">
+        <BdDropdownItem
+          v-for="language in languages"
+          :key="language.code"
+          :active="language.code === currentLanguage"
+          @click="emit('languageChange', language)"
+        >
+          {{ language.name }}
+        </BdDropdownItem>
+      </BdDropdown>
     </nav>
   </div>
 </template>
 
 <script lang="ts" setup>
-import { BdOption, BdSelect } from "bearded-ui";
+import { BdDropdown, BdDropdownItem } from "bearded-ui";
 import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
 
 import { LanguageOption } from "@/@types/Wikipedia";
@@ -56,39 +58,20 @@ const emit = defineEmits<{
 }>();
 
 const sentinelRef = ref<HTMLElement | null>(null);
-const selectedSection = ref("");
 const isStuck = ref(false);
 
 const hasSections = computed(() => props.sections.length > 0);
 const hasMultipleLanguages = computed(() => props.languages.length > 1);
 
-const sectionOptions = computed<BdOption[]>(() =>
-  props.sections.map((section) => ({
-    label: section.title,
-    value: section.id,
-  })),
-);
-
-const languageOptions = computed<BdOption[]>(() =>
-  props.languages.map((language) => ({
-    label: language.name,
-    value: language.code,
-  })),
+const currentLanguageName = computed(
+  () => props.languages.find((language) => language.code === props.currentLanguage)?.name ?? props.currentLanguage,
 );
 
 // Observer to detect when nav is stuck
 let observer: IntersectionObserver | null = null;
 
-function onLanguageChange(code: number | string | undefined): void {
-  const option = props.languages.find((language) => language.code === code);
-  if (option) emit("languageChange", option);
-}
-
-function onSectionChange(value: number | string | undefined): void {
-  const sectionId = String(value);
+function onSectionChange(sectionId: string): void {
   scrollToSection(sectionId);
-  // Reset selection to allow re-selecting the same section
-  selectedSection.value = "";
   emit("sectionChange", sectionId);
 }
 

--- a/src/components/frame/FrameIndex.vue
+++ b/src/components/frame/FrameIndex.vue
@@ -7,7 +7,7 @@ v-show="!frameStore.isMinimized" :class="{ 'is-closing': frameStore.isClosing }"
     <div
 ref="wrapperRef" v-motion :initial="{ scale: 0.8, opacity: 0, y: 50 }"
       :enter="{ scale: 1, opacity: 1, y: 0, transition: { type: 'spring', stiffness: 200, damping: 20 } }"
-      :class="{ minimized: frameStore.isMinimized }" class="iframe-wrap"
+      :class="{ 'is-closing': frameStore.isClosing, minimized: frameStore.isMinimized }" class="iframe-wrap"
 >
       <BdLoader class="load" />
       <div class="head">
@@ -18,7 +18,7 @@ ref="wrapperRef" v-motion :initial="{ scale: 0.8, opacity: 0, y: 50 }"
           <BdButton size="small" @click="frameStore.close()">Close</BdButton>
         </div>
       </div>
-      <iframe :class="{ 'is-closing': frameStore.isClosing }" :src="frameStore.url" border="0" />
+      <iframe :src="frameStore.url" border="0" />
     </div>
   </div>
 </template>
@@ -103,6 +103,23 @@ watch(
   }
 }
 
+/*
+ * Uses the individual `scale` property so it composes with the inline
+ * `transform` @vueuse/motion leaves behind after the opening spring instead of
+ * fighting it. Timed to match the 200ms the store waits before unmounting.
+ */
+@keyframes bye-frame {
+  from {
+    opacity: 1;
+    scale: 1;
+  }
+
+  to {
+    opacity: 0;
+    scale: 0.9;
+  }
+}
+
 .bg {
   animation: pop-bg 0.2s ease both;
   background-color: var(--bg-color-darker);
@@ -155,6 +172,12 @@ watch(
   pointer-events: all;
   z-index: 1000;
 
+  /* The whole box leaves as one piece — panel, header and iframe together. */
+  &.is-closing {
+    animation: bye-frame 0.2s ease both;
+    pointer-events: none;
+  }
+
   &.minimized {
     pointer-events: none;
     visibility: hidden;
@@ -167,9 +190,5 @@ iframe {
   border-radius: 10px;
   height: 80dvh;
   width: 80vw;
-
-  &.is-closing {
-    animation: bye-bg 0.2s ease both;
-  }
 }
 </style>

--- a/src/components/frame/FrameIndex.vue
+++ b/src/components/frame/FrameIndex.vue
@@ -137,11 +137,15 @@ watch(
   width: 100%;
   z-index: 999;
 
+  /*
+   * Centred with auto margins, not a transform: BdLoader spins with the
+   * `rotate` property, and a `transform` here would compose with it into an
+   * orbit around a point half the loader away.
+   */
   .load {
-    left: 50%;
+    inset: 0;
+    margin: auto;
     position: absolute;
-    top: 50%;
-    transform: translate(-50%, -50%);
   }
 }
 

--- a/src/components/player/PlayerControls.vue
+++ b/src/components/player/PlayerControls.vue
@@ -60,29 +60,22 @@
 </template>
 
 <script lang="ts" setup>
-import { useIntervalFn } from "@vueuse/core";
-import { computed, ref, watch } from "vue";
+import { computed } from "vue";
 
 import { usePlayer } from "@/components/player/PlayerStore";
 import IconButton from "@/components/ui/IconButton.vue";
+import { usePlaybackClock } from "@/composables/usePlaybackClock";
 import { timecode } from "@/helpers/date";
 
 const props = defineProps<{ forceMobile?: boolean }>();
 const playerStore = usePlayer();
-const currentTime = ref<number>(0);
+/*
+ * Shared with the seek bar. These two used to count on their own — 1s here,
+ * 200ms there — so the number could sit up to 1.5s away from the bar it
+ * describes, and a keyboard scrub moved the bar while the number stood still.
+ */
+const { position: currentTime } = usePlaybackClock();
 const duration = computed(() => playerStore.playerState?.duration);
-
-useIntervalFn(() => {
-  if (!playerStore.playerState) return;
-  if (!playerStore.playerState.paused) currentTime.value = currentTime.value + 1000;
-}, 1000);
-
-watch(
-  () => playerStore.playerState.position,
-  (newPos) => {
-    if (Math.abs(newPos - currentTime.value) > 1500) currentTime.value = newPos;
-  },
-);
 </script>
 
 <style scoped>

--- a/src/components/player/PlayerEpisode.vue
+++ b/src/components/player/PlayerEpisode.vue
@@ -6,13 +6,10 @@
         :cover-url="coverUrl(playerStore.currentFromSDK?.album.images, 'medium')"
       />
       <BdLoader v-else />
-      <Controls
-        :duration="playerStore.currentFromSDK && playerStore.currentFromSDK.duration_ms"
-        :progress="playerStore.currentPositionFromSDK"
-      />
+      <Controls />
       <Device />
     </div>
-    <SeekBar :duration="playerStore.currentFromSDK && playerStore.currentFromSDK.duration_ms" />
+    <SeekBar />
   </div>
 </template>
 

--- a/src/components/player/PlayerStore.ts
+++ b/src/components/player/PlayerStore.ts
@@ -27,6 +27,13 @@ const RETRY_DELAY_MS = 300;
 const HEARTBEAT_FAILURE_THRESHOLD = 3;
 const HEARTBEAT_FAILURE_NOTIFY_COOLDOWN_MS = 5 * 60 * 1000;
 const VOLUME_LOCK_DURATION_MS = 2000;
+/*
+ * A seek on an external device is acknowledged by Spotify long after the PUT
+ * returns, and `getExternalPlayerState()` polls every 2s — so a poll already in
+ * flight comes back carrying the position we just left. Long enough to outlive
+ * one poll round-trip.
+ */
+const SEEK_LOCK_DURATION_MS = 2000;
 
 export const usePlayer = defineStore("player", {
   actions: {
@@ -49,7 +56,9 @@ export const usePlayer = defineStore("player", {
 
     async _executeDeviceSwitch(targetDeviceId: string, retries: number): Promise<void> {
       this.isSettingDevice = true;
-      this.playerState = defaultPlaybackState;
+      // Copied, not aliased: assigning the module-level default made every later
+      // mutation of `playerState.position` rewrite the default itself.
+      this.playerState = { ...defaultPlaybackState };
 
       const startTime = Date.now();
       const hasTimedOut = (): boolean => Date.now() - startTime >= DEVICE_SWITCH_TIMEOUT_MS;
@@ -211,7 +220,7 @@ export const usePlayer = defineStore("player", {
       current.id = item.id;
       current.name = item.name;
       current.uri = item.uri;
-      playerState.position = data.progress_ms;
+      if (Date.now() >= (this.seekLockUntil ?? 0)) playerState.position = data.progress_ms;
       playerState.paused = !data.is_playing;
       playerState.shuffle = data.shuffle_state;
       playerState.duration = item.duration_ms;
@@ -280,10 +289,30 @@ export const usePlayer = defineStore("player", {
       instance().post("me/player/previous");
     },
 
+    /**
+     * Jump to a position in the current track, optimistically.
+     *
+     * The only place the user loses something irrecoverable when a call fails —
+     * their place in the track — so unlike the original this one puts the old
+     * position back and says so, the way `toggleShuffle` already did.
+     * @param progress - Target position in milliseconds
+     */
     async seek(progress: number): Promise<void> {
+      const previousProgress = this.currentlyPlaying.progress_ms;
+      const previousPosition = this.playerState.position;
+
       this.currentlyPlaying.progress_ms = progress;
       this.playerState.position = progress;
-      await instance().put(`me/player/seek?position_ms=${Math.round(progress)}`);
+      this.seekLockUntil = Date.now() + SEEK_LOCK_DURATION_MS;
+      try {
+        await instance().put(`me/player/seek?position_ms=${Math.round(progress)}`);
+      } catch (err) {
+        if (import.meta.env.DEV) console.error("Failed to seek:", err);
+        this.seekLockUntil = 0;
+        this.currentlyPlaying.progress_ms = previousProgress;
+        this.playerState.position = previousPosition;
+        notification({ msg: "Failed to seek", type: NotificationType.Error });
+      }
     },
 
     async setDevice(deviceId: null | string, retries = 3): Promise<void> {
@@ -490,6 +519,7 @@ export const usePlayer = defineStore("player", {
     playerState: defaultPlaybackState,
     queue: [],
     queueOpened: false,
+    seekLockUntil: 0,
     thisDeviceId: "",
     volumeLockUntil: 0,
   }),

--- a/src/components/player/SeekBar.vue
+++ b/src/components/player/SeekBar.vue
@@ -3,9 +3,9 @@
     <div ref="progressWrap" class="progress-wrap">
       <div class="progress">
         <div v-if="playerStore.playerState" :style="{ transform: `scaleX(${playedRatio})` }" class="bar" />
-        <div :style="`width:${perc}%`" class="seek">
+        <div :style="`width:${previewPercent}%`" class="seek">
           <div class="time font-bold">
-            {{ time }}
+            {{ previewTime }}
           </div>
         </div>
       </div>
@@ -16,13 +16,14 @@
         where seeking used to be switched off entirely.
       -->
       <input
-        :value="currentTime"
-        :aria-valuetext="`${timecode(currentTime)} of ${timecode(playerStore.playerState?.duration)}`"
-        :max="playerStore.playerState?.duration || 0"
+        :value="position"
+        :aria-valuetext="`${timecode(position) || '0:00'} of ${timecode(duration) || '0:00'}`"
+        :disabled="!duration"
+        :max="duration"
+        :step="step"
         aria-label="Seek"
         class="range"
         min="0"
-        step="1000"
         type="range"
         @change="onCommit"
         @input="onScrub"
@@ -32,62 +33,59 @@
 </template>
 
 <script lang="ts" setup>
-import { useIntervalFn, useMouseInElement } from "@vueuse/core";
-import { computed, onMounted, onUnmounted, ref, watch } from "vue";
+import { useMouseInElement } from "@vueuse/core";
+import { computed, ref } from "vue";
 
 import { usePlayer } from "@/components/player/PlayerStore";
+import { usePlaybackClock } from "@/composables/usePlaybackClock";
 import { timecode } from "@/helpers/date";
+
+/** Arrow-key steps to cross the whole track. 200 keeps a 4min song at 1s and an hour-long episode at 18s. */
+const KEYBOARD_STEPS = 200;
+const MIN_STEP_MS = 1000;
 
 const progressWrap = ref<HTMLDivElement>();
 
-const { elementWidth, elementX } = useMouseInElement(progressWrap);
-const perc = ref<number>(0);
-const time = ref<string>("");
+const { elementWidth, elementX, isOutside } = useMouseInElement(progressWrap);
 const playerStore = usePlayer();
-const currentTime = ref<number>(0);
+const { position, setPosition, setScrubbing } = usePlaybackClock();
+
+const duration = computed<number>(() => playerStore.playerState?.duration ?? 0);
+
+/*
+ * One arrow press covers a fixed share of the track instead of a fixed second.
+ * At the old flat 1s, crossing an hour-long episode took 3600 presses.
+ */
+const step = computed<number>(() => Math.max(MIN_STEP_MS, Math.round(duration.value / KEYBOARD_STEPS)));
+
+const playedRatio = computed<number>(() => (duration.value ? Math.min(position.value / duration.value, 1) : 0));
+
+/*
+ * The read-out previews a position you have not committed to. With a pointer it
+ * follows the pointer; opened by keyboard focus it follows the scrub instead.
+ */
+const previewPercent = computed<number>(() => {
+  // Pointer away means the read-out was opened by keyboard focus, so it tracks
+  // the position being scrubbed rather than collapsing to the left edge.
+  if (isOutside.value || !elementWidth.value) return playedRatio.value * 100;
+  return Math.min(Math.max((elementX.value / elementWidth.value) * 100, 0), 100);
+});
+
+const previewTime = computed<string>(() => timecode((duration.value / 100) * previewPercent.value) || "0:00");
 
 // Scrubbing only moves the painted bar; the seek request goes out on release.
 const onScrub = (e: Event): void => {
-  currentTime.value = Number((e.target as HTMLInputElement).value);
+  setScrubbing(true);
+  setPosition(Number((e.target as HTMLInputElement).value));
 };
 
 const onCommit = (e: Event): void => {
   const target = Number((e.target as HTMLInputElement).value);
-  currentTime.value = target;
+
+  setPosition(target);
+  setScrubbing(false);
   playerStore.seek(target);
 };
-
-// The hover read-out stays mouse-only by design: it previews a position you
-// have not committed to, which only means something with a pointer.
-const handleMouseMove = (): void => {
-  perc.value = (elementX.value / elementWidth.value) * 100;
-  const durationPerc = playerStore.playerState?.duration && (playerStore.playerState?.duration / 100) * perc.value;
-  if (durationPerc) time.value = timecode(durationPerc);
-};
-
-onMounted(() => progressWrap.value?.addEventListener("mousemove", handleMouseMove));
-onUnmounted(() => progressWrap.value?.removeEventListener("mousemove", handleMouseMove));
-
-const playedRatio = computed(() => {
-  const duration = playerStore.playerState?.duration;
-  return duration ? Math.min(currentTime.value / duration, 1) : 0;
-});
-
-const freq = 200;
-useIntervalFn(() => {
-  if (!playerStore.playerState) return;
-  // ponytail: clamp so a stale "playing" state can't run the timer past the track length
-  if (!playerStore.playerState.paused) {
-    currentTime.value = Math.min(currentTime.value + freq, playerStore.playerState.duration);
-  }
-}, freq);
-
-watch(
-  () => playerStore.playerState.position,
-  (newPosition) => {
-    if (Math.abs(newPosition - currentTime.value) > 1500) currentTime.value = newPosition;
-  },
-);
 </script>
 
 <style scoped>
@@ -98,7 +96,7 @@ watch(
   }
 
   to {
-    opacity: 1;
+    opacity: 0.5;
   }
 }
 
@@ -113,12 +111,16 @@ watch(
 .progress {
   background: var(--bg-color-light);
   border-radius: 1rem;
-  flex: 1;
   height: 0.2rem;
   position: relative;
 
   .seek {
-    animation: pop-seek 0.5s ease 0s both;
+    /*
+     * 120ms, and the keyframe lands on the resting opacity rather than on 1:
+     * an animation outranks a plain declaration and `both` holds that override
+     * forever, so the old `to { opacity: 1 }` quietly killed the 0.5 below it.
+     */
+    animation: pop-seek 0.12s ease both;
     background-color: var(--bg-color-lighter);
     border-radius: 1rem;
     bottom: 0;
@@ -129,12 +131,22 @@ watch(
     position: absolute;
     top: 0;
 
+    /*
+     * Neutral chip, not an accent one. White on `--primary-color` measures
+     * 3.85:1 at this size — under the 4.5 small text needs — and the accent is
+     * user-chosen, so no fixed foreground can be guaranteed against it. The
+     * theme's own text/background pair is contrasty in both themes by
+     * construction, and it leaves the accent to the bar it floats above.
+     */
     .time {
-      background: var(--primary-color);
+      background: var(--bg-color-darker);
       border-radius: 0.3rem;
       bottom: calc(100% + 0.4rem);
-      color: var(--font-color-light);
+      color: var(--font-color);
       font-size: var(--font-size-sm);
+
+      /* Same as the timecode in the controls: the digits must not shift width mid-scrub. */
+      font-variant-numeric: tabular-nums;
       padding: 0.1rem 0.4rem;
       pointer-events: none;
       position: absolute;
@@ -184,11 +196,39 @@ watch(
     position: absolute;
     width: 100%;
     z-index: 2;
+
+    &:disabled {
+      cursor: default;
+    }
   }
 
+  /*
+   * A range spreads its value over the track minus one thumb width, so a click
+   * lands up to half a thumb from the pixel it hit — 8px of a 1400px bar is
+   * 20 seconds of an hour-long episode, and the hover read-out, which follows
+   * the pointer exactly, made the gap visible. A zero-width thumb maps the
+   * value linearly across the whole bar; the position is painted by `.bar`.
+   */
+  .range::-webkit-slider-thumb {
+    appearance: none;
+    height: 100%;
+    width: 0;
+  }
+
+  .range::-moz-range-thumb {
+    border: 0;
+    height: 100%;
+    width: 0;
+  }
+
+  /* Keyboard scrubbing needs the read-out too — the bar alone is 2px tall. */
   &:has(.range:focus-visible) {
     outline: 2px solid var(--primary-color);
     outline-offset: 2px;
+
+    .seek {
+      display: block;
+    }
   }
 
   @media (pointer: coarse) {

--- a/src/components/player/device/DeviceVolume.vue
+++ b/src/components/player/device/DeviceVolume.vue
@@ -65,13 +65,21 @@ onMounted(() => {
   sliderPercent.value = volumeToSliderPercent(playerStore.devices.activeDevice.volume_percent ?? 0);
 });
 
+/*
+ * Snaps the slider back onto the device volume, unless it already sits on a
+ * position that produces it. The gamma curve is not round-trip exact once both
+ * ends are integers — a click at 10% stores volume 2, which maps back to 11% —
+ * so resyncing unconditionally nudged the bar away from the pixel just clicked.
+ */
+function syncSliderToDevice(): void {
+  const volume = currentDeviceVolume.value;
+
+  if (sliderPercentToVolume(sliderPercent.value) === volume) return;
+  sliderPercent.value = volumeToSliderPercent(volume);
+}
+
 // If volume changes externally, update the slider
-watch(
-  () => playerStore.devices.activeDevice.volume_percent,
-  (val) => {
-    sliderPercent.value = volumeToSliderPercent(val ?? 0);
-  },
-);
+watch(() => playerStore.devices.activeDevice.volume_percent, syncSliderToDevice);
 
 // The request goes out once the value settles, so a drag across the bar is one
 // call to Spotify instead of one per pixel.
@@ -82,7 +90,7 @@ async function onCommit(e: Event): Promise<void> {
 
 function onLeave(): void {
   // reset preview to current volume
-  sliderPercent.value = volumeToSliderPercent(currentDeviceVolume.value);
+  syncSliderToDevice();
 }
 
 function onMove(e: MouseEvent): void {
@@ -233,6 +241,25 @@ async function toggleMute(): Promise<void> {
     position: absolute;
     width: 100%;
     z-index: 10;
+  }
+
+  /*
+   * A range spreads its value over the track minus one thumb width, so a click
+   * lands up to half a thumb (~8px of a 96px bar) off the pixel it hit — and
+   * the wedge, which follows the pointer exactly, made the gap obvious. A
+   * zero-width thumb maps the value linearly across the whole bar. Nothing is
+   * lost visually: the position is painted by `.cursor` and `.hover`.
+   */
+  .range::-webkit-slider-thumb {
+    appearance: none;
+    height: 100%;
+    width: 0;
+  }
+
+  .range::-moz-range-thumb {
+    border: 0;
+    height: 100%;
+    width: 0;
   }
 
   &:hover {

--- a/src/composables/usePlaybackClock.ts
+++ b/src/composables/usePlaybackClock.ts
@@ -1,0 +1,82 @@
+import { useIntervalFn } from "@vueuse/core";
+import { effectScope, ref, type Ref, watch } from "vue";
+
+import { usePlayer } from "@/components/player/PlayerStore";
+
+/**
+ * How often the local clock advances. The seek bar's `transition` matches this
+ * exactly, so every transition is replaced the frame it ends and the bar moves
+ * continuously instead of stepping.
+ */
+const TICK_MS = 200;
+
+/**
+ * How far the local clock may drift from the player before it snaps back.
+ * Below this, the SDK's own jitter would make the read-out twitch.
+ */
+const RESYNC_THRESHOLD_MS = 1500;
+
+const position = ref<number>(0);
+/*
+ * Held while a drag is in progress. Without it the ticker kept adding 200ms to
+ * the value bound to the range, so the thumb crept forward under a finger that
+ * was holding still.
+ */
+const held = ref<boolean>(false);
+/*
+ * Detached: the interval and the watcher belong to the module, not to whichever
+ * component happened to call first — otherwise unmounting that component (the
+ * mobile slide-up, say) would stop the clock for the desktop bar still on screen.
+ */
+const scope = effectScope(true);
+let started = false;
+
+/**
+ * The single playback clock, shared by every component that shows a position.
+ *
+ * There used to be two: the seek bar counted at 200ms and the timecode at
+ * 1000ms, each resyncing on its own threshold. They drifted up to 1.5s apart,
+ * so the number under the bar disagreed with the bar — and a keyboard scrub
+ * moved the bar while the number sat still, because it was watching the store
+ * rather than the drag.
+ */
+export function usePlaybackClock(): {
+  position: Ref<number>;
+  setPosition: (ms: number) => void;
+  setScrubbing: (scrubbing: boolean) => void;
+} {
+  const playerStore = usePlayer();
+
+  if (!started) {
+    started = true;
+    scope.run(() => {
+      useIntervalFn(() => {
+        const state = playerStore.playerState;
+
+        if (held.value || !state || state.paused) return;
+        // Clamped: a stale "playing" state would otherwise run the clock past the track.
+        position.value = Math.min(position.value + TICK_MS, state.duration);
+      }, TICK_MS);
+
+      watch(
+        () => playerStore.playerState.position,
+        (newPosition) => {
+          if (held.value) return;
+          if (Math.abs(newPosition - position.value) > RESYNC_THRESHOLD_MS) position.value = newPosition;
+        },
+      );
+    });
+  }
+
+  return {
+    position,
+    /** Moves the clock without waiting for the store — used while scrubbing. */
+    setPosition: (ms: number): void => {
+      position.value = ms;
+    },
+    /** Freezes the clock for the length of a drag, so the value cannot move under the pointer. */
+    setScrubbing: (scrubbing: boolean): void => {
+      held.value = scrubbing;
+    },
+  };
+}

--- a/src/helpers/useKeyboardEvents.ts
+++ b/src/helpers/useKeyboardEvents.ts
@@ -4,17 +4,41 @@ import { watch } from "vue";
 import { useDialog } from "@/components/dialog/DialogStore";
 import { usePlayer } from "@/components/player/PlayerStore";
 
+/** How far one arrow press moves the playhead. Matches what podcast apps use for a skip button. */
+const SEEK_DELTA_MS = 10_000;
+
 /**
  * Register global keyboard shortcuts for the player:
  * - Shift+Up / Shift+Down: adjust volume by 2%
+ * - Shift+Left / Shift+Right: seek by 10 seconds
  * - Space (on body): toggle play/pause
  * - Ctrl/Cmd+K: open search
  */
 export function useKeyboardEvents(): void {
   const playerStore = usePlayer();
   const dialogStore = useDialog();
-  const { shift_down, shift_up } = useMagicKeys();
+  const { shift_down, shift_left, shift_right, shift_up } = useMagicKeys();
   const delta = 2;
+
+  /*
+   * Shift-modified like the volume pair, for the same reason: a bare arrow key
+   * belongs to whatever is focused — a list, a scroll container, the seek bar's
+   * own range — and stealing it globally would break all three.
+   */
+  const seekBy = (offset: number): void => {
+    const duration = playerStore.playerState?.duration;
+
+    if (!duration) return;
+    playerStore.seek(Math.min(Math.max(playerStore.playerState.position + offset, 0), duration));
+  };
+
+  watch(shift_right, (v) => {
+    if (v) seekBy(SEEK_DELTA_MS);
+  });
+
+  watch(shift_left, (v) => {
+    if (v) seekBy(-SEEK_DELTA_MS);
+  });
 
   watch(shift_up, (v) => {
     const currentVolume = playerStore.devices.activeDevice ? playerStore.devices.activeDevice.volume_percent : 0;

--- a/src/views/genre/GenreArtistCard.vue
+++ b/src/views/genre/GenreArtistCard.vue
@@ -99,10 +99,14 @@ async function goToArtist(): Promise<void> {
   }
 }
 
+/*
+ * Auto margins rather than a transform — BdLoader spins with `rotate`, and a
+ * transform here would turn the spin into an orbit. The bottom inset pulls the
+ * centre 0.8rem up, clear of the label.
+ */
 .spinner {
-  left: 50%;
+  inset: 0 0 1.6rem;
+  margin: auto;
   position: absolute;
-  top: calc(50% - 0.8rem);
-  transform: translate(-50%, -50%);
 }
 </style>


### PR DESCRIPTION
Suite de #262 : ces commits ont été poussés sur la branche après le merge de la PR, ils ne sont donc jamais arrivés sur `master`.

## Contenu

- `refactor(artist)` — `BdSelect` remplacé par `BdDropdown` dans la navigation
- `docs` — section UI library dans CLAUDE.md (bearded-ui en dossier voisin, composants en priorité upstream)
- `chore(deps)` — deux bumps de bearded-ui (`9a55d62`, `e3a0c50`)
- `fix(frame)` — la modale iframe sort d'une pièce : `is-closing` déplacé sur `.iframe-wrap`, double fade supprimé
- `fix(player)` — volume : thumb à largeur zéro (le clic atterrit sous le curseur) + resync conditionnelle (l'aller-retour gamma ne repousse plus la barre)
- `fix(player)` — seek : même correction de mapping, `try/catch` + rollback + notification dans `seek()`, `seekLockUntil` contre le rubber-band sur device externe, `:disabled` tant que la durée est inconnue, `Shift+←/→` = ±10 s, step proportionnel, read-out au focus clavier
- `feat` — `usePlaybackClock` : une seule horloge partagée par la seek bar et les timecodes, à la place des deux tickers concurrents qui divergeaient jusqu'à 1,5 s

## Vérification

`bun run lint` (vue-tsc + ESLint + Stylelint) et les 152 tests passent.

Non vérifié à la main : le comportement du verrou de seek sur un device Spotify distant (dépend d'une latence réseau réelle) et l'absence de conflit OS sur `Shift+←/→`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)