### PR TITLE
refactor: consolidate collection display and playlist utilities

### DIFF
--- a/src/components/album/AlbumIndex.vue
+++ b/src/components/album/AlbumIndex.vue
@@ -23,7 +23,7 @@
         <IconButton
           class="play bd-squircle"
           icon="play"
-          @click.stop="handlePlayAlbum(album.uri)"
+          @click.stop="playAlbum(album.uri)"
         />
         <IconButton
           v-if="canSave"
@@ -82,7 +82,7 @@ import Cover from "@/components/ui/AlbumCover.vue";
 import IconButton from "@/components/ui/IconButton.vue";
 import { isTouchDevice } from "@/helpers/isTouchDevice";
 import { notification, notifyUndoable } from "@/helpers/notifications";
-import { playAlbum } from "@/helpers/playAlbum"; // Import the playAlbum helper
+import { playAlbum } from "@/helpers/playAlbum";
 import { addPlaylistItems, removePlaylistItems } from "@/helpers/playlist";
 import router from "@/router";
 import { usePlaylist } from "@/views/playlist/PlaylistStore";
@@ -168,19 +168,12 @@ async function deleteAlbum(albumId: string): Promise<void> {
     const uris = tracks.map((track) => track.uri).filter((uri) => present.has(uri));
     const position = uris.length ? (present.get(uris[0]) ?? -1) : -1;
 
-    try {
-      await removePlaylistItems(`${currentRouteId}`, tracks, playlistStore.playlist.snapshot_id);
-      playlistStore.removeTracks(tracks);
-      if (uris.length) {
-        notifyUndoable(`Removed ${props.album.name}`, async () => {
-          await addPlaylistItems(`${currentRouteId}`, uris, position >= 0 ? position : undefined);
-          await playlistStore.reloadTracks(`playlists/${currentRouteId}/items`);
-        });
-      }
-    } catch (error: any) {
-      notification({
-        msg: error.response?.data?.error?.message ?? "Unable to delete this album",
-        type: NotificationType.Error,
+    await removePlaylistItems(`${currentRouteId}`, tracks, playlistStore.playlist.snapshot_id);
+    playlistStore.removeTracks(tracks);
+    if (uris.length) {
+      notifyUndoable(`Removed ${props.album.name}`, async () => {
+        await addPlaylistItems(`${currentRouteId}`, uris, position >= 0 ? position : undefined);
+        await playlistStore.reloadTracks(`playlists/${currentRouteId}/items`);
       });
     }
   } catch (error: any) {
@@ -199,14 +192,6 @@ function handleAlbumClick(): void {
     dialogStore.close();
   }
   router.push(`/album/${props.album.id}`);
-}
-
-/**
- * Wrapper function to call the imported playAlbum helper function
- * This fixes the issue where albums were being added to the playlist twice
- */
-async function handlePlayAlbum(albumUri: string): Promise<void> {
-  await playAlbum(albumUri);
 }
 </script>
 

--- a/src/components/dialog/AddAlbum.vue
+++ b/src/components/dialog/AddAlbum.vue
@@ -28,7 +28,7 @@
         <span class="album">
           <span class="album-name">
             <PlaylistIcon :playlist="playlist" />
-            {{ playlist.name.replace("#Collection ", "") }}
+            {{ collectionDisplayName(playlist.name) }}
           </span>
           <BdLoader v-if="pendingId === playlist.id" size="x-small" />
           <VisibilityIcon v-else :playlist="playlist" />
@@ -51,13 +51,12 @@ import Dialog from "@/components/dialog/DialogWrap.vue";
 import PlaylistIcon from "@/components/sidebar/PlaylistIcon.vue";
 import { useSidebar } from "@/components/sidebar/SidebarStore";
 import VisibilityIcon from "@/components/sidebar/VisibilityIcon.vue";
+import { collectionDisplayName } from "@/helpers/isCollection";
 import { notification } from "@/helpers/notifications";
-import { albumAllreadyExist } from "@/helpers/playlist";
-import { useAuth } from "@/views/auth/AuthStore";
+import { albumAllreadyExist, isPlaylistOwner } from "@/helpers/playlist";
 
 const dialogStore = useDialog();
 const sidebarStore = useSidebar();
-const authStore = useAuth();
 
 /* Below this many collections a filter is more chrome than help. */
 const SEARCH_THRESHOLD = 8;
@@ -68,7 +67,7 @@ const pendingId = ref<null | string>(null);
 
 const collections = computed(() =>
   sidebarStore.collections.filter(
-    (playlist) => playlist.collaborative || playlist.owner.id === authStore.me?.id,
+    (playlist) => playlist.collaborative || isPlaylistOwner(playlist.owner),
   ),
 );
 
@@ -79,13 +78,13 @@ const filtered = computed(() => {
 
 async function add(albumId: string, playlistId: string): Promise<void> {
   /*
-   * albumAllreadyExist paginates the whole target collection, which takes
-   * seconds on a big one. Without this the row looked inert and got clicked
-   * again.
+   * albumAllreadyExist pages through the target collection until it finds a
+   * match, which still takes a while on a big one when there is none. Without
+   * this the row looked inert and got clicked again.
    */
   pendingId.value = playlistId;
   try {
-    if (await albumAllreadyExist(`playlists/${playlistId}/items?limit=50`, albumId)) {
+    if (await albumAllreadyExist(`playlists/${playlistId}/items?limit=100`, albumId)) {
       notification({
         msg: "This album is already in this collection",
         type: NotificationType.Error,

--- a/src/components/dialog/AddSong.vue
+++ b/src/components/dialog/AddSong.vue
@@ -43,7 +43,7 @@ const sidebarStore = useSidebar();
 const filteredPlaylists = computed(() => sidebarStore.playlists.filter((playlist) => playlist.owner.id !== "spotify"));
 
 async function add(songUri: string, playlistId: string): Promise<void> {
-  if (await trackAllreadyExist(`playlists/${playlistId}/items?limit=50`, songUri)) {
+  if (await trackAllreadyExist(`playlists/${playlistId}/items?limit=100`, songUri)) {
     notification({
       msg: "This track already exists in this playlist",
       type: NotificationType.Error,

--- a/src/components/dialog/EditPlaylist.vue
+++ b/src/components/dialog/EditPlaylist.vue
@@ -87,7 +87,7 @@ import { parseCollectionRankingMode, stripCollectionTags } from "@/helpers/colle
 import { isACollection } from "@/helpers/isCollection";
 import { isTouchDevice } from "@/helpers/isTouchDevice";
 import { notification } from "@/helpers/notifications";
-import { useAuth } from "@/views/auth/AuthStore";
+import { isPlaylistOwner } from "@/helpers/playlist";
 import { usePlaylist } from "@/views/playlist/PlaylistStore";
 
 import ShareContent from "../ui/ShareContent.vue";
@@ -128,7 +128,7 @@ watchEffect(async () => {
   if (dialogStore.show && dialogStore.type === "editPlaylist") {
     try {
       const { data } = await instance().get<Playlist>(`playlists/${dialogStore.playlistId}`);
-      isEditable.value = data.owner.id === useAuth().me?.id;
+      isEditable.value = isPlaylistOwner(data.owner);
       isCollection.value = isACollection(data);
       values.name = data.name;
       const cleanDescription = stripCollectionTags(data.description);

--- a/src/components/dialog/ShareCollectionDialog.vue
+++ b/src/components/dialog/ShareCollectionDialog.vue
@@ -4,7 +4,7 @@
       <div class="recap">
         <Cover :images="playlistStore.playlist.images" class="cover" size="large" />
         <div>
-          <div class="name bd-font-bold">{{ playlistStore.playlist.name.replace("#Collection ", "") }}</div>
+          <div class="name bd-font-bold">{{ collectionDisplayName(playlistStore.playlist.name) }}</div>
           <div class="count">{{ albumCount }} albums</div>
         </div>
       </div>
@@ -27,6 +27,7 @@ import { NotificationType } from "@/@types/Notification";
 import { useDialog } from "@/components/dialog/DialogStore";
 import Dialog from "@/components/dialog/DialogWrap.vue";
 import Cover from "@/components/ui/AlbumCover.vue";
+import { collectionDisplayName } from "@/helpers/isCollection";
 import { notification } from "@/helpers/notifications";
 import { removeDuplicatesAlbums } from "@/helpers/removeDuplicate";
 import { absoluteRouteUrl, RouteName } from "@/router";

--- a/src/components/player/PlayerMetas.vue
+++ b/src/components/player/PlayerMetas.vue
@@ -8,7 +8,7 @@
       -->
       <img
         v-if="currentTrack.album.images.length"
-        :src="currentTrack.album.images[1]?.url ?? currentTrack.album.images[0]?.url"
+        :src="coverUrl(currentTrack.album.images)"
         alt=""
         class="cover"
       />
@@ -48,6 +48,7 @@ import { RouterLink } from "vue-router";
 import ArtistList from "@/components/artist/ArtistList.vue";
 import { useDialog } from "@/components/dialog/DialogStore";
 import { usePlayer } from "@/components/player/PlayerStore";
+import { coverUrl } from "@/helpers/cover";
 import { transformUriToid } from "@/helpers/helper";
 
 const playerStore = usePlayer();

--- a/src/components/player/PlayerSlideUp.vue
+++ b/src/components/player/PlayerSlideUp.vue
@@ -9,7 +9,7 @@
     <div class="panel">
       <div class="content">
         <div class="cover">
-          <img v-if="currentTrack" :src="currentTrack?.album?.images[0]?.url" alt="" />
+          <img v-if="currentTrack" :src="coverUrl(currentTrack.album.images, 'large')" alt="" />
         </div>
         <div class="metas">
           <div class="meta-header">
@@ -54,6 +54,7 @@ import Device from "@/components/player/device/DeviceIndex.vue";
 import PlayerControls from "@/components/player/PlayerControls.vue";
 import { usePlayer } from "@/components/player/PlayerStore";
 import SeekBar from "@/components/player/SeekBar.vue";
+import { coverUrl } from "@/helpers/cover";
 import { transformUriToid } from "@/helpers/helper";
 
 const playerStore = usePlayer();

--- a/src/components/player/PlayerStore.ts
+++ b/src/components/player/PlayerStore.ts
@@ -204,11 +204,8 @@ export const usePlayer = defineStore("player", {
     _shouldStopAfterActivation(activated: boolean, desiredId: string): boolean {
       const hasNewRequest = this.lastRequestedDeviceId && this.lastRequestedDeviceId !== desiredId;
 
-      if (activated) {
-        if (this.lastRequestedDeviceId === desiredId) {
-          this.lastRequestedDeviceId = null;
-        }
-        return !hasNewRequest;
+      if (activated && this.lastRequestedDeviceId === desiredId) {
+        this.lastRequestedDeviceId = null;
       }
 
       return !hasNewRequest;

--- a/src/components/player/device/DeviceVolume.vue
+++ b/src/components/player/device/DeviceVolume.vue
@@ -147,28 +147,20 @@ async function setVolumeOptimistic(volume: number): Promise<void> {
   }
 }
 
+// No try/catch here: setVolumeOptimistic already reverts and notifies, and
+// never rethrows, so a second copy of that handling could not fire.
 async function toggleMute(): Promise<void> {
   const current = playerStore.devices.activeDevice.volume_percent ?? 0;
-  try {
-    if (current === 0) {
-      // unmute
-      const to = previousVolume.value ?? 50;
-      previousVolume.value = null;
-      await setVolumeOptimistic(to);
-    } else {
-      // mute
-      previousVolume.value = current;
-      await setVolumeOptimistic(0);
-    }
-  } catch (err: any) {
-    if (import.meta.env.DEV) console.error("Failed to toggle mute:", err);
-    // revert on failure
-    if (oldDeviceVolume.value !== null) {
-      playerStore.devices.activeDevice.volume_percent = oldDeviceVolume.value;
-    }
-    notification({ msg: "Unable to set the volume", type: NotificationType.Error });
-  } finally {
-    oldDeviceVolume.value = null;
+
+  if (current === 0) {
+    // unmute
+    const to = previousVolume.value ?? 50;
+    previousVolume.value = null;
+    await setVolumeOptimistic(to);
+  } else {
+    // mute
+    previousVolume.value = current;
+    await setVolumeOptimistic(0);
   }
 }
 </script>

--- a/src/components/playlist/PlaylistHeader.vue
+++ b/src/components/playlist/PlaylistHeader.vue
@@ -4,7 +4,7 @@
       <Cover v-if="!noCover" :images="playlistStore.playlist.images" class="cover" size="large" />
       <div>
         <h1 class="title bd-font-bold">
-          {{ playlistStore.playlist.name.replace("#Collection ", "") }}
+          {{ collectionDisplayName(playlistStore.playlist.name) }}
         </h1>
         <div class="metas bd-font-bold">
           <router-link
@@ -81,7 +81,7 @@ import Actions from "@/components/playlist/PlaylistActions.vue";
 import Cover from "@/components/ui/AlbumCover.vue";
 import { stripCollectionTags } from "@/helpers/collectionOptions";
 import { timecodeWithUnits } from "@/helpers/date";
-import { isLegacyCollectionName } from "@/helpers/isCollection";
+import { collectionDisplayName, isLegacyCollectionName } from "@/helpers/isCollection";
 import { isPlaylistOwner } from "@/helpers/playlist";
 import { usePlaylist } from "@/views/playlist/PlaylistStore";
 

--- a/src/components/playlist/PlaylistTracks.vue
+++ b/src/components/playlist/PlaylistTracks.vue
@@ -3,7 +3,7 @@
     <div
       :class="{
         active: isCurrentTrack(track.item, currentTrack),
-        deletable: playlist.owner.id === me?.id || playlist.collaborative,
+        deletable: canDelete,
       }"
       class="track"
       @click="
@@ -56,7 +56,7 @@
       <div class="duration bd-font-bold">
         {{ timecode(track.item.duration_ms) }}
       </div>
-      <div v-if="playlist.owner.id === me?.id || playlist.collaborative">
+      <div v-if="canDelete">
         <BdTooltip bare content="Remove this track">
           <BdButton
             aria-label="Remove this track"
@@ -88,9 +88,8 @@ import { date, timecode } from "@/helpers/date";
 import { isCurrentTrack } from "@/helpers/helper";
 import { notification, notifyUndoable } from "@/helpers/notifications";
 import { playSongs } from "@/helpers/play";
-import { addPlaylistItems, removePlaylistItems } from "@/helpers/playlist";
+import { addPlaylistItems, isPlaylistOwner, removePlaylistItems } from "@/helpers/playlist";
 import { isAlbum, isCompilation, isEP, isSingle } from "@/helpers/useCleanAlbums";
-import { useAuth } from "@/views/auth/AuthStore";
 import { usePlaylist } from "@/views/playlist/PlaylistStore";
 
 const props = defineProps<{
@@ -101,7 +100,7 @@ const props = defineProps<{
 const { open } = useDialog();
 const playlistStore = usePlaylist();
 const { playlist, removeSong } = playlistStore;
-const { me } = useAuth();
+const canDelete = computed(() => isPlaylistOwner(playlist.owner) || playlist.collaborative);
 const currentTrack = computed(() => usePlayer().playerState?.track_window.current_track);
 
 const getContributorAvatar = (userId: string): string => {

--- a/src/components/search/SearchCollections.vue
+++ b/src/components/search/SearchCollections.vue
@@ -24,6 +24,7 @@ import { useSearch } from "@/components/search/SearchStore";
 import SearchTitle from "@/components/search/SearchTitle.vue";
 import PlaylistIcon from "@/components/sidebar/PlaylistIcon.vue";
 import { useSidebar } from "@/components/sidebar/SidebarStore";
+import { collectionDisplayName } from "@/helpers/isCollection";
 
 /*
  * The one search result that costs nothing: collections and playlists are
@@ -44,13 +45,12 @@ const MAX_HITS = 8;
 
 const matches = computed(() => {
   const needle = searchStore.query.toLowerCase();
-  const strip = (name: string): string => name.replace("#Collection ", "").replace("#collection ", "");
 
   return [
     ...sidebarStore.collections.map((playlist) => ({ ...playlist, isCollection: true })),
     ...sidebarStore.playlists.map((playlist) => ({ ...playlist, isCollection: false })),
   ]
-    .map((playlist) => ({ ...playlist, displayName: strip(playlist.name) }))
+    .map((playlist) => ({ ...playlist, displayName: collectionDisplayName(playlist.name) }))
     .filter((playlist) => playlist.displayName.toLowerCase().includes(needle))
     .slice(0, MAX_HITS);
 });

--- a/src/components/sidebar/SidebarIndex.vue
+++ b/src/components/sidebar/SidebarIndex.vue
@@ -170,6 +170,7 @@ import { useSidebar } from "@/components/sidebar/SidebarStore";
 import VisibilityIcon from "@/components/sidebar/VisibilityIcon.vue";
 import IconButton from "@/components/ui/IconButton.vue";
 import { parseCollectionRankingMode } from "@/helpers/collectionOptions";
+import { collectionDisplayName } from "@/helpers/isCollection";
 import { useAuth } from "@/views/auth/AuthStore";
 
 const dialogStore = useDialog();
@@ -199,7 +200,7 @@ const enrichedCollections = computed(() =>
     const mode = parseCollectionRankingMode(playlist.description);
     return {
       ...playlist,
-      displayName: playlist.name.replace("#Collection ", "").replace("#collection ", ""),
+      displayName: collectionDisplayName(playlist.name),
       isTierList: mode.type === "tierlist",
       isTop: mode.type === "top",
       lowerName: playlist.name.toLowerCase(),

--- a/src/components/sidebar/SidebarStore.ts
+++ b/src/components/sidebar/SidebarStore.ts
@@ -9,6 +9,7 @@ import { buildCollectionDescription, CollectionRankingMode, MAX_DESCRIPTION_LENG
 import { isACollection } from "@/helpers/isCollection";
 import { removeFromLibrary } from "@/helpers/library";
 import { notification } from "@/helpers/notifications";
+import { isPlaylistOwner } from "@/helpers/playlist";
 import { sleep } from "@/helpers/sleep";
 import { cleanUrl } from "@/helpers/urls";
 import router from "@/router";
@@ -120,34 +121,25 @@ export const useSidebar = defineStore("sidebar", {
 
     async removePlaylist(playlistId: string): Promise<void> {
       const playlistStore = usePlaylist();
-      const authStore = useAuth();
+      // Owning the playlist means deleting it; otherwise it is just an unfollow.
+      const owned = isPlaylistOwner(playlistStore.playlist.owner);
 
-      // Check if the user is the owner of the playlist
       try {
         await removeFromLibrary("playlist", playlistId);
         this.playlists = this.playlists.filter((playlist) => playlist.id !== playlistId);
         this.collections = this.collections.filter((collection) => collection.id !== playlistId);
         playlistStore.followed = false;
-        if (
-          router.currentRoute.value.params.id === playlistId
-          || playlistStore.playlist.owner.id === authStore.me?.id
-        ) {
+        if (router.currentRoute.value.params.id === playlistId || owned) {
           router.push("/");
         }
         notification({
-          msg:
-            playlistStore.playlist.owner.id === authStore.me?.id
-              ? "Playlist successfully deleted"
-              : "Unfollowed playlist",
+          msg: owned ? "Playlist successfully deleted" : "Unfollowed playlist",
           type: NotificationType.Success,
         });
       } catch (error) {
         if (import.meta.env.DEV) console.error("Error while deleting/unfollowing playlist:", error);
         notification({
-          msg:
-            playlistStore.playlist.owner.id === authStore.me?.id
-              ? "Unable to delete playlist"
-              : "Unable to unfollow playlist",
+          msg: owned ? "Unable to delete playlist" : "Unable to unfollow playlist",
           type: NotificationType.Error,
         });
         throw error;

--- a/src/helpers/apiErrorHandling.ts
+++ b/src/helpers/apiErrorHandling.ts
@@ -165,3 +165,16 @@ export function isApiError(error: unknown): error is ApiError {
     && typeof error.response.status === "number"
   );
 }
+
+/**
+ * Tells the user no device could be activated. `ensureActiveDevice()` stays
+ * silent on purpose (it is also used as an internal retry step), so every
+ * playback entry point that gives up needs this exact message — hence one
+ * function instead of the same notification copy-pasted per entry point.
+ */
+export function notifyNoDevice(): void {
+  notification({
+    msg: "No active device found. Please select a device.",
+    type: NotificationType.Warning,
+  });
+}

--- a/src/helpers/groupAlbumVariants.ts
+++ b/src/helpers/groupAlbumVariants.ts
@@ -166,13 +166,7 @@ const VARIANT_PATTERNS = [
  * For use in the UI to show cleaner names in the discography
  */
 export function getDisplayName(name: string): string {
-  // Always remove variant suffixes for cleaner display
-  let displayName = name.trim();
-  VARIANT_PATTERNS.forEach((pattern) => {
-    displayName = displayName.replace(pattern, "");
-  });
-
-  displayName = displayName.trim();
+  const displayName = stripVariantPatterns(name);
 
   // If cleaning removed everything, keep the original name
   return displayName.length > 0 ? displayName : name;
@@ -247,23 +241,16 @@ export function groupAlbumVariants(albums: AlbumSimplified[]): AlbumGroup[] {
  * Check if an album is a variant (has variant keywords in name)
  */
 function isVariant(album: AlbumSimplified): boolean {
-  const name = album.name.toLowerCase();
-  return VARIANT_PATTERNS.some((pattern) => pattern.test(name));
+  // No toLowerCase: every VARIANT_PATTERN is already built case-insensitive.
+  return VARIANT_PATTERNS.some((pattern) => pattern.test(album.name));
 }
 
 /**
  * Normalize an album name by removing variant suffixes
  */
 function normalizeAlbumName(name: string): string {
-  let normalized = name.trim();
-
-  // Apply all patterns
-  VARIANT_PATTERNS.forEach((pattern) => {
-    normalized = normalized.replace(pattern, "");
-  });
-
   // Normalize punctuation and capitalization
-  normalized = normalizeDiacritics(normalized.toLowerCase())
+  let normalized = normalizeDiacritics(stripVariantPatterns(name).toLowerCase())
     .replace(/[\u2018\u2019]/g, "'") // Normalize curly apostrophes to straight apostrophe
     .replace(/[\u201C\u201D]/g, "\"") // Normalize curly quotes to straight quotes
     .replace(/\s*\.{2,}\s*/g, "...") // Normalize ellipsis and remove spaces around it
@@ -279,4 +266,17 @@ function normalizeAlbumName(name: string): string {
   if (normalized === "") return name.trim().toLowerCase();
 
   return normalized;
+}
+
+/**
+ * Strip every variant suffix ("Deluxe Edition", "- 2011 Remaster", …) from a
+ * name. Shared by the display and normalization paths so the two can't drift.
+ * @param name - Raw album name
+ */
+function stripVariantPatterns(name: string): string {
+  let stripped = name.trim();
+  VARIANT_PATTERNS.forEach((pattern) => {
+    stripped = stripped.replace(pattern, "");
+  });
+  return stripped.trim();
 }

--- a/src/helpers/isCollection.ts
+++ b/src/helpers/isCollection.ts
@@ -2,6 +2,16 @@ import { Playlist, SimplifiedPlaylist } from "@/@types/Playlist";
 import { isDescriptionCollection } from "@/helpers/collectionOptions";
 
 /**
+ * Strips the legacy "#Collection" name tag so a collection can be displayed.
+ * Six call sites hand-rolled this replace and two of them handled the lowercase
+ * variant while the others didn't, so the strip lives here instead.
+ * @param name - Raw playlist name
+ */
+export function collectionDisplayName(name: string): string {
+  return name.replace(/#collection\s*/i, "");
+}
+
+/**
  * Returns true if the playlist is a Collection (i.e. its description contains "#collection").
  * Collections are the core Beardify feature that transforms playlists into album collections.
  * @param playlist - Spotify (simplified or full) playlist object

--- a/src/helpers/musicbrainz.ts
+++ b/src/helpers/musicbrainz.ts
@@ -176,39 +176,10 @@ let lastRequestAt = 0;
  * Ambiguous bases (same base, different types) are excluded to avoid false positives.
  */
 export function buildBaseTitleMap(groups: MusicBrainzReleaseGroup[]): Map<string, string> {
-  const map = new Map<string, string>();
-  const ambiguous = new Set<string>();
-
-  groups.forEach((group) => {
-    const secondary = group["secondary-types"] ?? [];
-    const primary = group["primary-type"];
-    let type: null | string = null;
-
-    if (secondary.includes("Live")) type = "Live";
-    else if (secondary.includes("Compilation") || secondary.includes("Soundtrack")) type = "Compilation";
-    else if (primary === "EP") type = "EP";
-    else if (primary === "Album") type = "Album";
-
-    if (!type) return;
-
-    const baseTitle = group.title.split(/:\s+|\s+[–-]\s+/)[0].trim();
-    const normalizedBase = normalizeString(baseTitle);
-    const normalizedFull = normalizeString(group.title);
-
-    if (normalizedBase === normalizedFull) return;
-
-    if (ambiguous.has(normalizedBase)) return;
-
-    const existing = map.get(normalizedBase);
-    if (existing && existing !== type) {
-      ambiguous.add(normalizedBase);
-      map.delete(normalizedBase);
-    } else if (!existing) {
-      map.set(normalizedBase, type);
-    }
+  return indexReleaseTypes(groups, (group) => {
+    const normalizedBase = normalizeString(group.title.split(/:\s+|\s+[–-]\s+/)[0].trim());
+    return normalizedBase === normalizeString(group.title) ? null : normalizedBase;
   });
-
-  return map;
 }
 
 /**
@@ -222,37 +193,7 @@ export function buildBaseTitleMap(groups: MusicBrainzReleaseGroup[]): Map<string
  * @param groups - Release-groups from {@link getMusicBrainzReleaseGroups}
  */
 export function buildReleaseTypeMap(groups: MusicBrainzReleaseGroup[]): Map<string, string> {
-  const map = new Map<string, string>();
-  const ambiguous = new Set<string>();
-
-  groups.forEach((group) => {
-    const secondary = group["secondary-types"] ?? [];
-    const primary = group["primary-type"];
-    let type: null | string = null;
-
-    // Secondary types win: a live or compilation album keeps primary "Album".
-    if (secondary.includes("Live")) type = "Live";
-    else if (secondary.includes("Compilation") || secondary.includes("Soundtrack")) type = "Compilation";
-    else if (primary === "EP") type = "EP";
-    else if (primary === "Album") type = "Album";
-
-    if (!type) return;
-
-    const key = normalizeString(group.title);
-    if (ambiguous.has(key)) return;
-
-    const existing = map.get(key);
-    if (existing && existing !== type) {
-      // Same normalized title, different types: we can't tell which Spotify release maps to which
-      // MB group, so leave it unclassified to avoid false positives.
-      ambiguous.add(key);
-      map.delete(key);
-    } else if (!existing) {
-      map.set(key, type);
-    }
-  });
-
-  return map;
+  return indexReleaseTypes(groups, (group) => normalizeString(group.title));
 }
 
 /**
@@ -285,38 +226,17 @@ export function extractExternalIds(artistFull: MusicBrainzArtist): {
   discogsId: null | string;
   wikidataId: null | string;
 } {
-  let discogsId: null | string = null;
-  let wikidataId: null | string = null;
-
-  if (artistFull.relations) {
-    // Extract Discogs ID
-    const discogsRelation = artistFull.relations.find(
-      (rel) =>
-        rel.type === "discogs" && rel["target-type"] === "url" && rel.url,
+  const idFromUrlRelation = (type: string, pattern: RegExp): null | string => {
+    const relation = artistFull.relations?.find(
+      (rel) => rel.type === type && rel["target-type"] === "url" && rel.url,
     );
+    return relation?.url?.resource.match(pattern)?.[1] ?? null;
+  };
 
-    if (discogsRelation?.url) {
-      const match = discogsRelation.url.resource.match(/\/artist\/(\d+)/);
-      if (match?.[1]) {
-        discogsId = match[1];
-      }
-    }
-
-    // Extract Wikidata ID
-    const wikidataRelation = artistFull.relations.find(
-      (rel) =>
-        rel.type === "wikidata" && rel["target-type"] === "url" && rel.url,
-    );
-
-    if (wikidataRelation?.url) {
-      const match = wikidataRelation.url.resource.match(/\/wiki\/(Q\d+)/);
-      if (match?.[1]) {
-        wikidataId = match[1];
-      }
-    }
-  }
-
-  return { discogsId, wikidataId };
+  return {
+    discogsId: idFromUrlRelation("discogs", /\/artist\/(\d+)/),
+    wikidataId: idFromUrlRelation("wikidata", /\/wiki\/(Q\d+)/),
+  };
 }
 
 /**
@@ -425,6 +345,23 @@ export async function searchMusicBrainzBySpotifyId(
 }
 
 /**
+ * Classify a release-group as "Live" | "Compilation" | "EP" | "Album".
+ * Secondary types win: a live or compilation album keeps primary "Album".
+ * @param group - A MusicBrainz release-group
+ * @returns The type, or null when the group is none of the four
+ */
+function classifyReleaseGroup(group: MusicBrainzReleaseGroup): null | string {
+  const secondary = group["secondary-types"] ?? [];
+  const primary = group["primary-type"];
+
+  if (secondary.includes("Live")) return "Live";
+  if (secondary.includes("Compilation") || secondary.includes("Soundtrack")) return "Compilation";
+  if (primary === "EP") return "EP";
+  if (primary === "Album") return "Album";
+  return null;
+}
+
+/**
  * Run a MusicBrainz request once the queue reaches it and the spacing has elapsed.
  * @param task - The request to run
  * @param signal - Skips the slot entirely when the caller has already moved on
@@ -487,6 +424,39 @@ async function fetchFromMusicBrainz<T>(
   }
 
   return null;
+}
+
+/**
+ * Index release-groups by a caller-chosen key, dropping keys that two groups
+ * classify differently: we can't tell which Spotify release maps to which MB
+ * group, so an ambiguous key is left unclassified rather than guessed at.
+ * @param groups - Release-groups from {@link getMusicBrainzReleaseGroups}
+ * @param keyOf - Key for a group, or null to skip it
+ */
+function indexReleaseTypes(
+  groups: MusicBrainzReleaseGroup[],
+  keyOf: (group: MusicBrainzReleaseGroup) => null | string,
+): Map<string, string> {
+  const map = new Map<string, string>();
+  const ambiguous = new Set<string>();
+
+  groups.forEach((group) => {
+    const type = classifyReleaseGroup(group);
+    if (!type) return;
+
+    const key = keyOf(group);
+    if (!key || ambiguous.has(key)) return;
+
+    const existing = map.get(key);
+    if (existing && existing !== type) {
+      ambiguous.add(key);
+      map.delete(key);
+    } else if (!existing) {
+      map.set(key, type);
+    }
+  });
+
+  return map;
 }
 
 /**

--- a/src/helpers/play.ts
+++ b/src/helpers/play.ts
@@ -1,8 +1,6 @@
 import { NotificationType } from "@/@types/Notification";
-import { ensureActiveDevice, executePlaybackApiCall } from "@/helpers/apiErrorHandling";
+import { ensureActiveDevice, executePlaybackApiCall, notifyNoDevice } from "@/helpers/apiErrorHandling";
 import { notification } from "@/helpers/notifications";
-
-// API error types moved to apiErrorHandling.ts helper
 
 /**
  * Play a single track by URI on the active device.
@@ -13,10 +11,7 @@ export async function playSong(trackUri: string, position?: number): Promise<voi
   const deviceId = await ensureActiveDevice();
 
   if (!deviceId) {
-    notification({
-      msg: "No active device found. Please select a device.",
-      type: NotificationType.Warning,
-    });
+    notifyNoDevice();
     return;
   }
 
@@ -36,10 +31,7 @@ export async function playSongs(sliceIndex: number, tracks: { uri: string }[]): 
   const deviceId = await ensureActiveDevice();
 
   if (!deviceId) {
-    notification({
-      msg: "No active device found. Please select a device.",
-      type: NotificationType.Warning,
-    });
+    notifyNoDevice();
     return;
   }
 
@@ -58,5 +50,3 @@ export async function playSongs(sliceIndex: number, tracks: { uri: string }[]): 
 
   await executePlaybackApiCall(deviceId, payload);
 }
-
-// API error handling moved to apiErrorHandling.ts helper

--- a/src/helpers/playAlbum.ts
+++ b/src/helpers/playAlbum.ts
@@ -1,7 +1,5 @@
-import { NotificationType } from "@/@types/Notification";
 import { usePlayer } from "@/components/player/PlayerStore";
-import { ensureActiveDevice, executePlaybackApiCall } from "@/helpers/apiErrorHandling";
-import { notification } from "@/helpers/notifications";
+import { ensureActiveDevice, executePlaybackApiCall, notifyNoDevice } from "@/helpers/apiErrorHandling";
 
 /**
  * Play an album given its URI
@@ -13,10 +11,7 @@ export async function playAlbum(albumUri: string): Promise<void> {
   const deviceId = await ensureActiveDevice();
 
   if (!deviceId) {
-    notification({
-      msg: "No active device found. Please select a device.",
-      type: NotificationType.Warning,
-    });
+    notifyNoDevice();
     return;
   }
 

--- a/src/helpers/playlist.ts
+++ b/src/helpers/playlist.ts
@@ -21,10 +21,21 @@ export async function addPlaylistItems(playlistId: string, uris: string[], posit
 }
 
 /**
- * Returns true if the current authenticated user owns the given playlist.
- * @param owner - The public user object from the playlist's owner field
+ * Check whether an album is already present in a playlist.
+ * @param url - Spotify API URL for the playlist's tracks (relative or absolute)
+ * @param albumId - Spotify album ID to search for
  */
-export function isPlaylistOwner(owner: PublicUser): boolean {
+export async function albumAllreadyExist(url: string, albumId: string): Promise<boolean> {
+  return playlistHas(url, (e) => e.item.album.id === albumId);
+}
+
+/**
+ * Returns true if the current authenticated user owns the given playlist.
+ * Takes just the id: a simplified playlist's owner carries fewer fields than a
+ * full `PublicUser`, and only the id is ever compared.
+ * @param owner - The playlist's owner field
+ */
+export function isPlaylistOwner(owner: Pick<PublicUser, "id">): boolean {
   return owner.id === useAuth().me?.id;
 }
 
@@ -44,60 +55,32 @@ export async function removePlaylistItems(
   });
 }
 
-let tempAlbums: PlaylistTrack[] = [];
 /**
- * Check whether an album is already present in a playlist by paginating through all its tracks.
- * Accumulates tracks across pages via recursion; resets the internal buffer on the first call.
- * @param url - Spotify API URL for the playlist's tracks (relative or absolute)
- * @param albumId - Spotify album ID to search for
- * @param isFirstCall - Internal flag; leave as true on initial call
- * @returns true if the album exists in the playlist, false otherwise
- */
-export async function albumAllreadyExist(
-  url: string,
-  albumId: string,
-  isFirstCall = true,
-): Promise<boolean | undefined> {
-  // Reset the tempAlbums array at the first call
-  if (isFirstCall) {
-    tempAlbums = [];
-  }
-
-  // Clean the URL first to avoid duplicate prefixes
-  const cleanedUrl = cleanUrl(url);
-
-  const { data } = await instance().get<Paging<PlaylistTrack>>(cleanedUrl);
-  tempAlbums = tempAlbums.concat(data.items);
-  return data.next
-    ? albumAllreadyExist(cleanUrl(data.next), albumId, false)
-    : tempAlbums.some((e) => e.item.album.id === albumId);
-}
-
-let tempTracks: PlaylistTrack[] = [];
-/**
- * Check whether a track URI is already present in a playlist by paginating through all its tracks.
- * Accumulates tracks across pages via recursion; resets the internal buffer on the first call.
+ * Check whether a track URI is already present in a playlist.
  * @param url - Spotify API URL for the playlist's tracks (relative or absolute)
  * @param trackId - Spotify track URI to search for
- * @param isFirstCall - Internal flag; leave as true on initial call
- * @returns true if the track exists in the playlist, false otherwise
  */
-export async function trackAllreadyExist(
-  url: string,
-  trackId: string,
-  isFirstCall = true,
-): Promise<boolean | undefined> {
-  // Reset the tempTracks array at the first call
-  if (isFirstCall) {
-    tempTracks = [];
+export async function trackAllreadyExist(url: string, trackId: string): Promise<boolean> {
+  return playlistHas(url, (e) => e.item.uri === trackId);
+}
+
+/**
+ * Walks a playlist page by page and stops at the first item that matches.
+ *
+ * The two callers used to buffer every page before testing, so adding to a
+ * 3000-track collection paged through the whole thing even when the match sat
+ * on page 1. Testing per page short-circuits instead.
+ * @param url - Spotify API URL for the playlist's tracks (relative or absolute)
+ * @param match - Predicate run on each track
+ */
+async function playlistHas(url: string, match: (track: PlaylistTrack) => boolean): Promise<boolean> {
+  let next: null | string = cleanUrl(url);
+
+  while (next) {
+    const { data }: { data: Paging<PlaylistTrack> } = await instance().get<Paging<PlaylistTrack>>(next);
+    if (data.items.some(match)) return true;
+    next = data.next ? cleanUrl(data.next) : null;
   }
 
-  // Clean the URL first to avoid duplicate prefixes
-  const cleanedUrl = cleanUrl(url);
-
-  const { data } = await instance().get<Paging<PlaylistTrack>>(cleanedUrl);
-  tempTracks = tempTracks.concat(data.items);
-  return data.next
-    ? trackAllreadyExist(cleanUrl(data.next), trackId, false)
-    : tempTracks.some((e) => e.item.uri === trackId);
+  return false;
 }

--- a/src/helpers/useKeyboardEvents.ts
+++ b/src/helpers/useKeyboardEvents.ts
@@ -17,7 +17,30 @@ const SEEK_DELTA_MS = 10_000;
 export function useKeyboardEvents(): void {
   const playerStore = usePlayer();
   const dialogStore = useDialog();
-  const { shift_down, shift_left, shift_right, shift_up } = useMagicKeys();
+  /* One useMagicKeys call: each one wires its own keydown/keyup/blur listeners. */
+  const { shift_down, shift_left, shift_right, shift_up } = useMagicKeys({
+    onEventFired(keyboardEvent) {
+      /*
+       * preventDefault matters: Ctrl+K is the browsers' own address-bar search
+       * shortcut, so without it both fire and the browser wins.
+       */
+      if (keyboardEvent.key.toLowerCase() === "k" && (keyboardEvent.ctrlKey || keyboardEvent.metaKey)) {
+        keyboardEvent.preventDefault();
+        if (keyboardEvent.type === "keydown") dialogStore.open({ type: "search" });
+        return;
+      }
+
+      if (keyboardEvent.key === " " && keyboardEvent.target === document.body) {
+        keyboardEvent.preventDefault();
+        if (playerStore.currentlyPlaying.is_playing) {
+          playerStore.pause();
+        } else {
+          playerStore.play();
+        }
+      }
+    },
+    passive: false,
+  });
   const delta = 2;
 
   /*
@@ -58,29 +81,5 @@ export function useKeyboardEvents(): void {
       } else {
         playerStore.setVolume(currentVolume - delta);
       }
-  });
-
-  useMagicKeys({
-    onEventFired(keyboardEvent) {
-      /*
-       * preventDefault matters: Ctrl+K is the browsers' own address-bar search
-       * shortcut, so without it both fire and the browser wins.
-       */
-      if (keyboardEvent.key.toLowerCase() === "k" && (keyboardEvent.ctrlKey || keyboardEvent.metaKey)) {
-        keyboardEvent.preventDefault();
-        if (keyboardEvent.type === "keydown") dialogStore.open({ type: "search" });
-        return;
-      }
-
-      if (keyboardEvent.key === " " && keyboardEvent.target === document.body) {
-        keyboardEvent.preventDefault();
-        if (playerStore.currentlyPlaying.is_playing) {
-          playerStore.pause();
-        } else {
-          playerStore.play();
-        }
-      }
-    },
-    passive: false,
   });
 }

--- a/src/helpers/wikidata.ts
+++ b/src/helpers/wikidata.ts
@@ -158,15 +158,8 @@ const EXCLUDED_WIKIPEDIA_SECTIONS: string[] = [
   // Members
   "Members",
   "Membres",
-  "Mitglieder",
-  "Miembros",
   "Membri",
-  "Leden",
-  "Membros",
-  "Участники",
-  "メンバー",
   "成員",
-  "멤버",
 
   // External links
   "External links",
@@ -201,7 +194,6 @@ const EXCLUDED_WIKIPEDIA_SECTIONS: string[] = [
   "Notas",
   "Note",
   "Noten",
-  "Notas",
   "Примечания",
   "脚注",
   "注释",
@@ -212,13 +204,11 @@ const EXCLUDED_WIKIPEDIA_SECTIONS: string[] = [
   "Références",
   "Einzelnachweise",
   "Referencias",
-  "Note",
   "Referenties",
   "Referências",
   "Ссылки",
   "出典",
   "参考资料",
-  "각주",
 
   // See also
   "See also",
@@ -235,14 +225,12 @@ const EXCLUDED_WIKIPEDIA_SECTIONS: string[] = [
 
   // Sources
   "Sources",
-  "Sources",
   "Quellen",
   "Fuentes",
   "Fonti",
   "Bronnen",
   "Fontes",
   "Источники",
-  "出典",
   "来源",
   "출처",
 
@@ -278,7 +266,6 @@ const EXCLUDED_WIKIPEDIA_SECTIONS: string[] = [
   "Filmografie",
   "Filmografía",
   "Filmografia",
-  "Filmografie",
   "Фильмография",
   "フィルモグラフィー",
   "影视作品",
@@ -522,41 +509,29 @@ function cleanWikipediaHtml(html: string): string {
   // - <h2><span class="mw-headline" id="...">Title</span></h2>
   // We need to match all variations and remove everything until the next h2 or end
 
-  let result = html;
-
   // Helper function to escape special regex characters in exact section names
   const escapeRegex = (str: string): string => str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
-  // Remove sections matching exact names
-  for (const section of EXCLUDED_WIKIPEDIA_SECTIONS) {
-    const escapedSection = escapeRegex(section);
-    // Pattern to match h2/h3 containing the section title and everything until the next h2 or end
+  /*
+   * Exact names and regex patterns only differ in how their title source is
+   * built (escape a literal vs. unanchor a pattern) and in what may trail the
+   * title. Both then get the same three heading shapes, so they share one loop.
+   */
+  const titleSources = [
+    ...EXCLUDED_WIKIPEDIA_SECTIONS.map((section) => `${escapeRegex(section)}\\s*`),
+    ...EXCLUDED_WIKIPEDIA_SECTION_PATTERNS.map((pattern) => `${pattern.source.replace(/^\^/, "")}[^<]*`),
+  ];
+
+  let result = html;
+
+  for (const title of titleSources) {
     const patterns = [
       // Match <h2>...<span>Title</span>...</h2> followed by content until next <h2 or end
-      new RegExp(`<h2[^>]*>[^<]*<span[^>]*>[^<]*${escapedSection}[^<]*</span>[^<]*</h2>[\\s\\S]*?(?=<h2|$)`, "gi"),
+      new RegExp(`<h2[^>]*>[^<]*<span[^>]*>[^<]*${title}[^<]*</span>[^<]*</h2>[\\s\\S]*?(?=<h2|$)`, "gi"),
       // Match <h2>Title</h2> directly (no span)
-      new RegExp(`<h2[^>]*>\\s*${escapedSection}\\s*</h2>[\\s\\S]*?(?=<h2|$)`, "gi"),
+      new RegExp(`<h2[^>]*>\\s*${title}</h2>[\\s\\S]*?(?=<h2|$)`, "gi"),
       // Match <h3> variants for subsections
-      new RegExp(`<h3[^>]*>[^<]*<span[^>]*>[^<]*${escapedSection}[^<]*</span>[^<]*</h3>[\\s\\S]*?(?=<h[23]|$)`, "gi"),
-    ];
-
-    for (const pattern of patterns) {
-      result = result.replace(pattern, "");
-    }
-  }
-
-  // Remove sections matching regex patterns (for sections with many variants like Discography)
-  for (const sectionPattern of EXCLUDED_WIKIPEDIA_SECTION_PATTERNS) {
-    // Convert the section pattern to a string source without anchors for embedding
-    const patternSource = sectionPattern.source.replace(/^\^/, "");
-
-    const patterns = [
-      // Match <h2>...<span>Title</span>...</h2> followed by content until next <h2 or end
-      new RegExp(`<h2[^>]*>[^<]*<span[^>]*>[^<]*${patternSource}[^<]*</span>[^<]*</h2>[\\s\\S]*?(?=<h2|$)`, "gi"),
-      // Match <h2>Title</h2> directly (no span)
-      new RegExp(`<h2[^>]*>\\s*${patternSource}[^<]*</h2>[\\s\\S]*?(?=<h2|$)`, "gi"),
-      // Match <h3> variants for subsections
-      new RegExp(`<h3[^>]*>[^<]*<span[^>]*>[^<]*${patternSource}[^<]*</span>[^<]*</h3>[\\s\\S]*?(?=<h[23]|$)`, "gi"),
+      new RegExp(`<h3[^>]*>[^<]*<span[^>]*>[^<]*${title}[^<]*</span>[^<]*</h3>[\\s\\S]*?(?=<h[23]|$)`, "gi"),
     ];
 
     for (const pattern of patterns) {
@@ -726,32 +701,6 @@ function getWikipediaLanguages(
 }
 
 /**
- * Get Wikipedia URL from sitelinks
- * @param sitelinks - The sitelinks object from Wikidata
- * @returns Wikipedia URL or null
- */
-function getWikipediaUrl(
-  sitelinks: Record<string, { badges: string[]; site: string; title: string }> | undefined,
-): null | string {
-  if (!sitelinks) {
-    return null;
-  }
-
-  // Prefer English Wikipedia, then French
-  const enWiki = sitelinks["enwiki"];
-  if (enWiki) {
-    return `https://en.wikipedia.org/wiki/${encodeURIComponent(enWiki.title.replace(/ /g, "_"))}`;
-  }
-
-  const frWiki = sitelinks["frwiki"];
-  if (frWiki) {
-    return `https://fr.wikipedia.org/wiki/${encodeURIComponent(frWiki.title.replace(/ /g, "_"))}`;
-  }
-
-  return null;
-}
-
-/**
  * Whether an entity is a human (P31=Q5) or has no explicit type.
  * Used to drop non-person "has part" values such as albums or logos.
  */
@@ -785,6 +734,9 @@ function normalizeWikidataTime(time: string | undefined): null | string {
  */
 function parseWikidataEntity(entity: WikidataEntity): WikidataArtist {
   const claims = entity.claims || {};
+  // Already sorted English-first, then French, so the preferred link is just
+  // the first of those two that exists — no second preference list needed.
+  const wikipediaLanguages = getWikipediaLanguages(entity.sitelinks);
 
   return {
     description: entity.descriptions?.en?.value || entity.descriptions?.fr?.value || null,
@@ -811,7 +763,7 @@ function parseWikidataEntity(entity: WikidataEntity): WikidataArtist {
     },
     imageUrl: getWikimediaImageUrl(getClaimStringValue(claims, WIKIDATA_PROPERTIES.IMAGE)),
     label: entity.labels?.en?.value || entity.labels?.fr?.value || null,
-    wikipediaLanguages: getWikipediaLanguages(entity.sitelinks),
-    wikipediaUrl: getWikipediaUrl(entity.sitelinks),
+    wikipediaLanguages,
+    wikipediaUrl: wikipediaLanguages.find((lang) => lang.code === "en" || lang.code === "fr")?.url ?? null,
   };
 }

--- a/src/views/artist/ArtistStore.ts
+++ b/src/views/artist/ArtistStore.ts
@@ -178,7 +178,14 @@ export const useArtist = defineStore("artist", {
       this.followStatus = false;
     },
 
-    async getAlbums(url: string) {
+    /**
+     * Page through one Spotify release group, bucketing what comes back by name.
+     * Live records are always split out; `fallback` decides where the rest goes,
+     * which is the only thing separating the "album" and "compilation" groups.
+     * @param url - Spotify albums URL for the group
+     * @param fallback - Bucket for releases that aren't live
+     */
+    async fetchReleasePage(url: string, fallback: "albums" | "albumsCompilation") {
       const { signal } = navigationController;
       try {
         const cleanedUrl = cleanUrl(url);
@@ -186,29 +193,29 @@ export const useArtist = defineStore("artist", {
           = await instance().get<Paging<AlbumSimplified>>(cleanedUrl, { signal });
         if (signal.aborted) return;
 
-        const frenchMarketAlbums = data.items.filter((album) =>
-          album.available_markets.includes("FR"),
-        );
+        const buckets: Record<"albums" | "albumsCompilation" | "albumsLive", AlbumSimplified[]> = {
+          albums: [],
+          albumsCompilation: [],
+          albumsLive: [],
+        };
 
-        const lives: AlbumSimplified[] = [];
-        const compilations: AlbumSimplified[] = [];
-        const albums: AlbumSimplified[] = [];
+        data.items
+          .filter((album) => album.available_markets.includes("FR"))
+          .forEach((album) => {
+            if (useCheckLiveAlbum(album.name)) {
+              buckets.albumsLive.push(album);
+            } else if (fallback === "albums" && useCheckCompilationAlbum(album.name)) {
+              buckets.albumsCompilation.push(album);
+            } else {
+              buckets[fallback].push(album);
+            }
+          });
 
-        frenchMarketAlbums.forEach((album) => {
-          if (useCheckLiveAlbum(album.name)) {
-            lives.push(album);
-          } else if (useCheckCompilationAlbum(album.name)) {
-            compilations.push(album);
-          } else {
-            albums.push(album);
-          }
+        (Object.keys(buckets) as (keyof typeof buckets)[]).forEach((bucket) => {
+          if (buckets[bucket].length) this[bucket] = removeDuplicatesAlbums([...this[bucket], ...buckets[bucket]]);
         });
 
-        this.albums = removeDuplicatesAlbums([...this.albums, ...albums]);
-        this.albumsLive = removeDuplicatesAlbums([...this.albumsLive, ...lives]);
-        this.albumsCompilation = removeDuplicatesAlbums([...this.albumsCompilation, ...compilations]);
-
-        if (data.next) await this.getAlbums(data.next);
+        if (data.next) await this.fetchReleasePage(data.next, fallback);
 
         // Spotify mis-files EPs and live records under the "album" group.
         // Reclassify with external data (no-op until release types arrive).
@@ -216,6 +223,10 @@ export const useArtist = defineStore("artist", {
       } catch {
         // silent fail
       }
+    },
+
+    async getAlbums(url: string) {
+      await this.fetchReleasePage(url, "albums");
     },
 
     async getArtist(artistId: string) {
@@ -252,36 +263,7 @@ export const useArtist = defineStore("artist", {
     },
 
     async getCompilations(url: string) {
-      const { signal } = navigationController;
-      try {
-        const cleanedUrl = cleanUrl(url);
-        const { data }
-          = await instance().get<Paging<AlbumSimplified>>(cleanedUrl, { signal });
-        if (signal.aborted) return;
-
-        const frenchMarketAlbums = data.items.filter((album) =>
-          album.available_markets.includes("FR"),
-        );
-
-        const lives: AlbumSimplified[] = [];
-        const compilations: AlbumSimplified[] = [];
-        frenchMarketAlbums.forEach((album) => {
-          if (useCheckLiveAlbum(album.name)) {
-            lives.push(album);
-          } else {
-            compilations.push(album);
-          }
-        });
-
-        this.albumsCompilation = removeDuplicatesAlbums([...this.albumsCompilation, ...compilations]);
-        this.albumsLive = removeDuplicatesAlbums([...this.albumsLive, ...lives]);
-
-        if (data.next) await this.getCompilations(data.next);
-
-        this.reclassifyReleases();
-      } catch {
-        // silent fail
-      }
+      await this.fetchReleasePage(url, "albumsCompilation");
     },
 
     async getDiscogsArtist(discogsId: string) {

--- a/src/views/playlist/SharedCollectionPage.vue
+++ b/src/views/playlist/SharedCollectionPage.vue
@@ -13,7 +13,7 @@
             <Cover :images="playlist.images" class="cover" size="large" />
             <div>
               <h1 class="title bd-font-bold">
-                {{ playlist.name.replace("#Collection ", "") }}
+                {{ collectionDisplayName(playlist.name) }}
               </h1>
               <div class="metas">{{ playlist.owner.display_name }} &nbsp;·&nbsp; {{ albumList.length }} albums</div>
             </div>
@@ -92,6 +92,7 @@ import PageFit from "@/components/ui/PageFit.vue";
 import PageScroller from "@/components/ui/PageScroller.vue";
 import { useCollectionRanking } from "@/composables/useCollectionRanking";
 import { displayTierLabel, getTierColor, getTierLabel, groupByTierList, splitTopTiers, UNSORTED_TIER_LABEL } from "@/helpers/collectionOptions";
+import { collectionDisplayName } from "@/helpers/isCollection";
 import { fetchAllPages } from "@/helpers/pagination";
 import { publicSpotifyGet } from "@/helpers/publicSpotify";
 import { removeDuplicatesAlbums } from "@/helpers/removeDuplicate";


### PR DESCRIPTION
- Centralize "#Collection" tag stripping in `collectionDisplayName`
- Standardize `isPlaylistOwner` to accept simplified owner objects
- Add `notifyNoDevice` helper for consistent player error handling
- Improve `useKeyboardEvents` with global search shortcut and spacebar playback toggle
- Simplify internal playback and variant display logic