### PR TITLE
fix(player): sync state when app returns to foreground

### DIFF
--- a/src/components/player/PlayerIndex.vue
+++ b/src/components/player/PlayerIndex.vue
@@ -64,7 +64,18 @@ watchEffect(() => {
   }
 });
 
-onMounted(() => watchExternalPlayerState());
+// Timers and the SDK socket both freeze while the machine sleeps, so the player can
+// wake up still showing "playing" long after the API moved to paused. Refetch the
+// real state every time the app comes back to the foreground.
+function syncOnVisible(): void {
+  if (document.visibilityState === "visible") playerStore.getExternalPlayerState().catch(() => {});
+}
+
+onMounted(() => {
+  watchExternalPlayerState();
+  syncOnVisible();
+  document.addEventListener("visibilitychange", syncOnVisible);
+});
 
 watch(
   () => playerStore.isExternalDevice,
@@ -73,6 +84,7 @@ watch(
 
 // Cleanup interval when component is unmounted
 onBeforeUnmount(() => {
+  document.removeEventListener("visibilitychange", syncOnVisible);
   if (interval.value !== undefined) {
     window.clearInterval(interval.value);
     interval.value = undefined;

--- a/src/components/player/PlayerStore.ts
+++ b/src/components/player/PlayerStore.ts
@@ -267,7 +267,12 @@ export const usePlayer = defineStore("player", {
         this.devices.activeDevice = data.device;
       }
 
-      if (!data.item) return;
+      if (!data?.item) {
+        // No item = nothing is playing. Without this, a local SDK state frozen by a
+        // long sleep keeps the UI on "playing" forever.
+        this.playerState.paused = true;
+        return;
+      }
       const { item } = data;
       const current = this.playerState.track_window.current_track;
       const playerState = this.playerState;
@@ -547,6 +552,11 @@ export const usePlayer = defineStore("player", {
     },
 
     syncPlayerState(state: Spotify.PlaybackState): void {
+      // The local SDK keeps emitting its own state even when playback lives on another
+      // device — including a state frozen by a long machine sleep. Trust it only while
+      // this device is the active one; `me/player` is the truth otherwise.
+      const activeId = this.devices.activeDevice?.id;
+      if (this.thisDeviceId && activeId && activeId !== this.thisDeviceId) return;
       this.playerState = state;
     },
 


### PR DESCRIPTION
Add a visibility change listener to force-sync playback state with the Spotify API when the app becomes visible, preventing the player from getting stuck on "playing" after long periods of system sleep. Added checks to ensure local SDK state updates only apply when this device is the active one.