### PR TITLE
fix(ui): add referrerpolicy no-referrer to AlbumCover

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,11 +14,11 @@
     "preview": "bun run build && vite preview",
     "tauri": "tauri",
     "tauri:dev": "tauri dev",
-    "tauri:build": "tauri build",
-    "tauri:build:debug": "tauri build --debug",
+    "tauri:build": "bun --env-file=.env run tauri build",
+    "tauri:build:debug": "bun --env-file=.env run tauri build --debug",
     "vite:dev-build": "vite build --mode development",
     "build:ci": "vite build",
-    "build:app": "bun run tauri build && bun run scripts/package-release.ts",
+    "build:app": "bun run tauri:build && bun run scripts/package-release.ts",
     "release": "bun run scripts/release.ts"
   },
   "dependencies": {

--- a/src/components/ui/AlbumCover.vue
+++ b/src/components/ui/AlbumCover.vue
@@ -1,5 +1,17 @@
 <template>
-  <img :alt="alt" :src="failed ? PLACEHOLDER : source" loading="lazy" @error="failed = true" />
+  <!--
+    `no-referrer`: albumoftheyear's CDN, which serves two thirds of the releases
+    feed's artwork, answers 403 to any request carrying a Referer — hotlink
+    protection, and it does not care which origin the header names. Sending none
+    is what the browser needs to be told to do; Spotify's CDN is indifferent.
+  -->
+  <img
+    :alt="alt"
+    :src="failed ? PLACEHOLDER : source"
+    loading="lazy"
+    referrerpolicy="no-referrer"
+    @error="failed = true"
+  />
 </template>
 
 <script lang="ts" setup>


### PR DESCRIPTION
Ensure album art loads from CDNs with strict hotlink protection by omitting the Referer header, and update Tauri build scripts to load environment variables correctly.